### PR TITLE
Add page size parameter to FactBatchRequestGenerator and CLI

### DIFF
--- a/src/functions/knowledge_extraction/core/fact_batch/request_generator.py
+++ b/src/functions/knowledge_extraction/core/fact_batch/request_generator.py
@@ -43,6 +43,7 @@ class FactBatchRequestGenerator:
         temperature: float = 0.1,
         chunk_size: int = 25,
         output_dir: Optional[Path] = None,
+        page_size: int = 200,
     ) -> None:
         self.reader = reader or NewsFactReader()
         self.model = model
@@ -50,6 +51,7 @@ class FactBatchRequestGenerator:
         self.chunk_size = chunk_size
         self.output_dir = output_dir or Path("./batch_files")
         self.output_dir.mkdir(exist_ok=True)
+        self.page_size = page_size
 
         logger.info(
             "Initialized FactBatchRequestGenerator",
@@ -57,6 +59,7 @@ class FactBatchRequestGenerator:
                 "model": model,
                 "temperature": temperature,
                 "chunk_size": chunk_size,
+                "page_size": page_size,
             },
         )
 
@@ -74,6 +77,7 @@ class FactBatchRequestGenerator:
 
         facts_iter = self.reader.stream_facts(
             limit=limit,
+            page_size=self.page_size,
             require_topics=task == "topics",
             require_entities=task == "entities",
         )

--- a/src/functions/knowledge_extraction/scripts/fact_knowledge_batch_cli.py
+++ b/src/functions/knowledge_extraction/scripts/fact_knowledge_batch_cli.py
@@ -48,6 +48,12 @@ def parse_args() -> argparse.Namespace:
         help="Number of facts per model request",
     )
     parser.add_argument(
+        "--page-size",
+        type=int,
+        default=200,
+        help="DB page size when streaming facts (lower to reduce DB timeouts)",
+    )
+    parser.add_argument(
         "--model",
         default="gpt-4.1-nano-2025-04-14",
         help="OpenAI model to use for knowledge extraction",
@@ -162,6 +168,7 @@ def main() -> None:
         temperature=args.temperature,
         chunk_size=args.chunk_size,
         output_dir=args.output_dir,
+        page_size=args.page_size,
     )
 
     if args.no_submit:


### PR DESCRIPTION
Introduce a page size parameter to enhance database streaming capabilities in the FactBatchRequestGenerator and CLI. This change allows users to specify the page size, helping to reduce database timeouts during fact streaming.