### PR TITLE
perf: reduce GPT-5-nano token usage by ~75-85%

### DIFF
--- a/.github/workflows/content-facts-entities-realtime.yml
+++ b/.github/workflows/content-facts-entities-realtime.yml
@@ -2,7 +2,7 @@ name: Content Facts Entities Realtime
 
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 concurrency:

--- a/src/functions/content_summarization/core/summary_batch/request_generator.py
+++ b/src/functions/content_summarization/core/summary_batch/request_generator.py
@@ -549,7 +549,7 @@ class SummaryBatchRequestGenerator:
                     "messages": [
                         {"role": "user", "content": f"{prompt}\n\n{user_content}"}
                     ],
-                    "max_completion_tokens": 4000,
+                    "max_completion_tokens": 2000,
                     "reasoning_effort": "low",
                 },
             }

--- a/src/functions/knowledge_extraction/core/batch/request_generator.py
+++ b/src/functions/knowledge_extraction/core/batch/request_generator.py
@@ -189,8 +189,8 @@ class BatchRequestGenerator:
             "body": {
                 "model": self.model,
                 "input": prompt,
-                "reasoning": {"effort": "medium"},
-                "text": {"verbosity": "medium"},
+                "reasoning": {"effort": "low"},
+                "text": {"verbosity": "low"},
             }
         }
     
@@ -205,8 +205,8 @@ class BatchRequestGenerator:
             "body": {
                 "model": self.model,
                 "input": prompt,
-                "reasoning": {"effort": "medium"},
-                "text": {"verbosity": "medium"},
+                "reasoning": {"effort": "low"},
+                "text": {"verbosity": "low"},
             }
         }
     

--- a/src/functions/knowledge_extraction/core/extraction/entity_extractor.py
+++ b/src/functions/knowledge_extraction/core/extraction/entity_extractor.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 import openai
 from openai import OpenAIError, RateLimitError, APITimeoutError
 
-from ..prompts import build_entity_extraction_prompt
+from ..prompts import build_entity_extraction_prompt, build_batched_entity_extraction_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +160,7 @@ class EntityExtractor:
                 response = openai.responses.create(
                     model=self.model,
                     input=prompt,
-                    reasoning={"effort": "medium"},
+                    reasoning={"effort": "low"},
                     text={"verbosity": "low"},
                     timeout=self.timeout,
                 )
@@ -310,6 +310,158 @@ class EntityExtractor:
             logger.error(f"Error parsing entity response: {e}", exc_info=True)
             return []
     
+    def extract_multi(
+        self,
+        facts: List[Dict],
+        max_entities_per_fact: int = 10,
+        chunk_size: int = 15,
+    ) -> Dict[str, List[ExtractedEntity]]:
+        """
+        Extract entities from multiple facts in a single API call per chunk.
+
+        Sends chunk_size facts at once, dramatically reducing prompt overhead
+        compared to one API call per fact.
+
+        Args:
+            facts: List of dicts with 'id' and 'fact_text' keys
+            max_entities_per_fact: Max entities to extract per fact
+            chunk_size: Number of facts per API call
+
+        Returns:
+            Dict mapping fact ID to list of extracted entities
+        """
+        results: Dict[str, List[ExtractedEntity]] = {}
+
+        # Process in chunks
+        for chunk_start in range(0, len(facts), chunk_size):
+            chunk = facts[chunk_start:chunk_start + chunk_size]
+            fact_texts = [f.get("fact_text", "") for f in chunk]
+            fact_ids = [f.get("id", "") for f in chunk]
+
+            if not any(fact_texts):
+                continue
+
+            # Check circuit breaker
+            try:
+                self._check_circuit_breaker()
+            except Exception as e:
+                logger.error(str(e))
+                for fid in fact_ids:
+                    results[fid] = []
+                continue
+
+            chunk_results = self._extract_multi_chunk(
+                fact_texts, fact_ids, max_entities_per_fact
+            )
+            results.update(chunk_results)
+
+        logger.info(f"Extracted entities for {len(results)} facts via batched extraction")
+        return results
+
+    def _extract_multi_chunk(
+        self,
+        fact_texts: List[str],
+        fact_ids: List[str],
+        max_entities_per_fact: int,
+    ) -> Dict[str, List[ExtractedEntity]]:
+        """Extract entities from a single chunk of facts via one API call."""
+        import json as json_mod
+
+        for attempt in range(self.max_retries):
+            try:
+                prompt = build_batched_entity_extraction_prompt(
+                    fact_texts, max_entities_per_fact
+                )
+
+                response = openai.responses.create(
+                    model=self.model,
+                    input=prompt,
+                    reasoning={"effort": "low"},
+                    text={"verbosity": "low"},
+                    timeout=self.timeout,
+                )
+
+                parsed = self._parse_multi_response(response.output_text, fact_ids)
+                self._record_success()
+                return parsed
+
+            except RateLimitError:
+                wait_time = min(2 ** attempt, 60)
+                logger.warning(
+                    f"Rate limit hit on multi-extract (attempt {attempt + 1}/{self.max_retries}). "
+                    f"Waiting {wait_time}s..."
+                )
+                if attempt < self.max_retries - 1:
+                    time.sleep(wait_time)
+                else:
+                    self._record_failure()
+
+            except APITimeoutError as e:
+                logger.warning(f"API timeout on multi-extract (attempt {attempt + 1}): {e}")
+                if attempt < self.max_retries - 1:
+                    time.sleep(2 ** attempt)
+                else:
+                    self._record_failure()
+
+            except OpenAIError as e:
+                logger.error(f"OpenAI error on multi-extract (attempt {attempt + 1}): {e}")
+                if attempt < self.max_retries - 1:
+                    time.sleep(2 ** attempt)
+                else:
+                    self._record_failure()
+
+            except Exception as e:
+                logger.error(f"Unexpected error in multi-extract: {e}", exc_info=True)
+                self._record_failure()
+                break
+
+        # On failure, return empty lists
+        return {fid: [] for fid in fact_ids}
+
+    def _parse_multi_response(
+        self, response_text: str, fact_ids: List[str]
+    ) -> Dict[str, List[ExtractedEntity]]:
+        """Parse the batched multi-fact response into per-fact entity lists."""
+        import json
+
+        results: Dict[str, List[ExtractedEntity]] = {fid: [] for fid in fact_ids}
+
+        try:
+            data = json.loads(response_text)
+
+            if not isinstance(data, list):
+                logger.error(f"Expected list response for multi-extract, got {type(data)}")
+                return results
+
+            for item in data:
+                if not isinstance(item, dict):
+                    continue
+
+                fact_index = item.get("fact_index")
+                if fact_index is None:
+                    continue
+
+                # fact_index is 1-based
+                idx = fact_index - 1
+                if idx < 0 or idx >= len(fact_ids):
+                    logger.warning(f"fact_index {fact_index} out of range")
+                    continue
+
+                fact_id = fact_ids[idx]
+                entity_list = item.get("entities", [])
+
+                # Reuse existing _parse_response by wrapping in expected format
+                wrapped = json.dumps({"entities": entity_list})
+                entities = self._parse_response(wrapped)
+                results[fact_id] = entities
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse multi-extract response: {e}")
+        except Exception as e:
+            logger.error(f"Error parsing multi-extract response: {e}", exc_info=True)
+
+        return results
+
     def extract_batch(
         self,
         summaries: List[Dict[str, str]],

--- a/src/functions/knowledge_extraction/core/extraction/entity_extractor.py
+++ b/src/functions/knowledge_extraction/core/extraction/entity_extractor.py
@@ -382,6 +382,18 @@ class EntityExtractor:
                 )
 
                 parsed = self._parse_multi_response(response.output_text, fact_ids)
+
+                # Treat parse failures (e.g., wrong shape / missing fact IDs) as failures
+                # so that the retry loop and circuit breaker behave correctly.
+                if not isinstance(parsed, dict) or any(fid not in parsed for fid in fact_ids):
+                    logger.error(
+                        "Failed to parse multi-extract response into expected shape; "
+                        "treating as failure and retrying."
+                    )
+                    self._record_failure()
+                    # Let the retry loop handle backoff / eventual exhaustion.
+                    continue
+
                 self._record_success()
                 return parsed
 

--- a/src/functions/knowledge_extraction/core/extraction/entity_extractor.py
+++ b/src/functions/knowledge_extraction/core/extraction/entity_extractor.py
@@ -460,7 +460,16 @@ class EntityExtractor:
                     continue
 
                 fact_id = fact_ids[idx]
-                entity_list = item.get("entities", [])
+                raw_entities = item.get("entities", [])
+                if not isinstance(raw_entities, list):
+                    logger.warning(
+                        "Expected 'entities' to be a list for fact_index %s, got %s; defaulting to empty list",
+                        fact_index,
+                        type(raw_entities),
+                    )
+                    entity_list = []
+                else:
+                    entity_list = raw_entities
 
                 # Reuse existing _parse_response by wrapping in expected format
                 wrapped = json.dumps({"entities": entity_list})

--- a/src/functions/knowledge_extraction/core/extraction/topic_extractor.py
+++ b/src/functions/knowledge_extraction/core/extraction/topic_extractor.py
@@ -189,7 +189,7 @@ class TopicExtractor:
                 response = openai.responses.create(
                     model=self.model,
                     input=prompt,
-                    reasoning={"effort": "medium"},
+                    reasoning={"effort": "low"},
                     text={"verbosity": "low"},
                     timeout=self.timeout,
                 )

--- a/src/functions/knowledge_extraction/core/prompts.py
+++ b/src/functions/knowledge_extraction/core/prompts.py
@@ -6,8 +6,30 @@ from textwrap import dedent
 
 TOPIC_EXTRACTION_PROMPT_TEMPLATE = dedent(
     """
-    Classify NFL topics from this text. Return ONLY categories from this list (exact names, lowercase):
-    Quarterback Performance & Analysis, Running Back & Rushing Game, Wide Receiver & Passing Game, Defense & Turnovers, Coaching & Play Calling, Injuries & Player Health, Team Performance & Trends, Season Outlook & Predictions, Rookies & Emerging Players, Draft & College Prospects, Trades, Signings & Roster Moves, Contracts & Cap Management, Game Analysis & Highlights, Statistics & Rankings, Fantasy Football Impact, Offseason & Training Camp, Special Teams & Kicking Game, Refereeing & Rules, Player Profiles & Interviews, Team Culture & Leadership, League News & Administration, Off-Field & Lifestyle, Media & Fan Reactions
+    Classify NFL topics from this text. Return ONLY categories from this list (exact names):
+    - Quarterback Performance & Analysis
+    - Running Back & Rushing Game
+    - Wide Receiver & Passing Game
+    - Defense & Turnovers
+    - Coaching & Play Calling
+    - Injuries & Player Health
+    - Team Performance & Trends
+    - Season Outlook & Predictions
+    - Rookies & Emerging Players
+    - Draft & College Prospects
+    - Trades, Signings & Roster Moves
+    - Contracts & Cap Management
+    - Game Analysis & Highlights
+    - Statistics & Rankings
+    - Fantasy Football Impact
+    - Offseason & Training Camp
+    - Special Teams & Kicking Game
+    - Refereeing & Rules
+    - Player Profiles & Interviews
+    - Team Culture & Leadership
+    - League News & Administration
+    - Off-Field & Lifestyle
+    - Media & Fan Reactions
 
     Rules: max {max_items} topics, ranked by importance (1=primary, 2=secondary, 3+=minor), confidence 0-1.
 

--- a/src/functions/knowledge_extraction/core/prompts.py
+++ b/src/functions/knowledge_extraction/core/prompts.py
@@ -6,244 +6,53 @@ from textwrap import dedent
 
 TOPIC_EXTRACTION_PROMPT_TEMPLATE = dedent(
     """
-    You are an expert NFL analyst specialized in topic extraction. Classify the key NFL themes from this story summary using the STANDARDIZED topic categories below.
+    Classify NFL topics from this text. Return ONLY categories from this list (exact names, lowercase):
+    Quarterback Performance & Analysis, Running Back & Rushing Game, Wide Receiver & Passing Game, Defense & Turnovers, Coaching & Play Calling, Injuries & Player Health, Team Performance & Trends, Season Outlook & Predictions, Rookies & Emerging Players, Draft & College Prospects, Trades, Signings & Roster Moves, Contracts & Cap Management, Game Analysis & Highlights, Statistics & Rankings, Fantasy Football Impact, Offseason & Training Camp, Special Teams & Kicking Game, Refereeing & Rules, Player Profiles & Interviews, Team Culture & Leadership, League News & Administration, Off-Field & Lifestyle, Media & Fan Reactions
 
-    **Allowed Topic Categories (return the EXACT category names):**
-    1. Quarterback Performance & Analysis
-    2. Running Back & Rushing Game
-    3. Wide Receiver & Passing Game
-    4. Defense & Turnovers
-    5. Coaching & Play Calling
-    6. Injuries & Player Health
-    7. Team Performance & Trends
-    8. Season Outlook & Predictions
-    9. Rookies & Emerging Players
-    10. Draft & College Prospects
-    11. Trades, Signings & Roster Moves
-    12. Contracts & Cap Management
-    13. Game Analysis & Highlights
-    14. Statistics & Rankings
-    15. Fantasy Football Impact
-    16. Offseason & Training Camp
-    17. Special Teams & Kicking Game
-    18. Refereeing & Rules
-    19. Player Profiles & Interviews
-    20. Team Culture & Leadership
-    21. League News & Administration
-    22. Off-Field & Lifestyle
-    23. Media & Fan Reactions
+    Rules: max {max_items} topics, ranked by importance (1=primary, 2=secondary, 3+=minor), confidence 0-1.
 
-    **Guidelines:**
-    - Return only categories from the list above. Do NOT invent new categories.
-    - If multiple categories apply, include each as a separate topic ranked by importance.
-    - Provide at most {max_items} categories, ordered by rank.
-    - Avoid player or team names (handled separately as entities).
-    - Keep confidence between 0 and 1 with two decimal precision.
+    Return JSON: {{"topics":[{{"topic":"<category>","confidence":0.95,"rank":1}}]}}
 
-    **RANKING SYSTEM:**
-    - Rank 1: Primary topic(s) - the main theme/focus of the story
-    - Rank 2: Secondary topics - important supporting themes
-    - Rank 3+: Minor topics - mentioned but not central
-
-    Return in JSON format, **ORDERED BY RANK** (rank 1 first, then 2, then 3, etc.):
-
-    {{
-      "topics": [
-        {{
-          "topic": "quarterback performance & analysis",
-          "confidence": 0.95,
-          "rank": 1
-        }},
-        {{
-          "topic": "injuries & player health",
-          "confidence": 0.90,
-          "rank": 1
-        }},
-        {{
-          "topic": "team performance & trends",
-          "confidence": 0.85,
-          "rank": 2
-        }}
-      ]
-    }}
-
-    **Story Summary:**
-
-    {summary_text}
-
-    **Your Response (JSON only):**
+    Text: {summary_text}
     """
 ).strip()
 
 ENTITY_EXTRACTION_PROMPT_TEMPLATE = dedent(
     """
-    You are an expert NFL analyst specialized in entity extraction. Your task is to extract ALL NFL entities from this story summary with COMPREHENSIVE COVERAGE and disambiguation information.
+    Extract ALL NFL entities from this text. Entity types: team, player, game, staff.
 
-    **CRITICAL INSTRUCTIONS - READ CAREFULLY:**
-    
-    1. **EXTRACT ALL ENTITIES** - Do not skip entities just because you lack some context. Extract everything you can identify.
-    2. **READ THE ENTIRE TEXT** - Scan through the complete summary to find ALL players, teams, and games mentioned.
-    3. **PRIORITIZE COMPLETENESS** - It's better to extract an entity with partial information than to miss it entirely.
-    4. **PROVIDE DISAMBIGUATION WHEN POSSIBLE** - Include position, team, or other identifying information whenever available in the text.
+    For each entity include: type, mention_text, confidence (0-1), rank (1=primary, 2=secondary, 3+=minor).
+    - team: also include team_name (full), team_abbr (NFL abbr e.g. NYJ, KC, IND)
+    - player: also include position (QB/RB/WR/TE/CB/DT/DE/LB/S/K/P), team_name, team_abbr. Infer position/team from context when available.
+    - staff: also include role (e.g. "General Manager", "Head Coach"), team_name, team_abbr
+    - game: also include teams array, context (week/round)
 
-    ═══════════════════════════════════════════════════════════════════════════════
+    Extract with partial info rather than skip. Prioritize completeness.
 
-    **ENTITY TYPE 1: TEAMS**
-    
-    **ALWAYS EXTRACT ALL TEAM MENTIONS - This is the highest priority.**
-    
-    Teams can appear in many forms:
-    - Full name: "New York Jets", "Kansas City Chiefs", "Indianapolis Colts"
-    - City/location only: "New York", "Indianapolis" (when clearly referring to the team)
-    - Nickname only: "Jets", "Chiefs", "Colts"
-    - Possessive: "Jets'", "Chiefs'", "team's"
-    - Contextual: "the team", "the organization" (extract ONLY when the context is unambiguous, e.g., the article is solely about one team)
-    
-    **How to extract:**
-    - mention_text: Use the exact text from the summary (e.g., "New York Jets", "Jets", "Indianapolis")
-    - team_name: Full team name (e.g., "New York Jets", "Indianapolis Colts")
-    - team_abbr: Standard NFL abbreviation if known (e.g., "NYJ", "IND", "KC")
-    - confidence: 0.95-1.0 for explicit mentions, 0.7-0.9 for contextual references
-    - For generic references ("the team", "the organization"), extract ONLY if the context makes it unambiguous which team is being referred to (e.g., the summary/article is solely about one team).
+    Return up to {max_items} entities as JSON ordered by rank:
+    {{"entities":[{{"type":"player","mention_text":"Sauce Gardner","position":"CB","team_name":"New York Jets","team_abbr":"NYJ","confidence":0.95,"rank":1}}]}}
 
-    **Examples:**
-    ✅ "New York Jets General Manager..." → {{"type": "team", "mention_text": "New York Jets", "team_name": "New York Jets", "team_abbr": "NYJ", "confidence": 1.0}}
-    ✅ "...the Jets received..." → {{"type": "team", "mention_text": "Jets", "team_name": "New York Jets", "team_abbr": "NYJ", "confidence": 0.95}}
-    ✅ "...sending them to Indianapolis" → {{"type": "team", "mention_text": "Indianapolis", "team_name": "Indianapolis Colts", "team_abbr": "IND", "confidence": 0.90}}
-    ✅ "the team's long-term success" (assuming the article is solely about the New York Jets) → {{"type": "team", "mention_text": "the team", "team_name": "New York Jets", "team_abbr": "NYJ", "confidence": 0.85}}
+    Text: {summary_text}
+    """
+).strip()
 
-    ═══════════════════════════════════════════════════════════════════════════════
+BATCHED_ENTITY_EXTRACTION_PROMPT_TEMPLATE = dedent(
+    """
+    Extract ALL NFL entities from each numbered fact below. Entity types: team, player, game, staff.
 
-    **ENTITY TYPE 2: PLAYERS**
-    
-    **EXTRACT ALL PLAYER MENTIONS - Include as much disambiguation info as available.**
-    
-    A player mention requires:
-    - REQUIRED: Player name (full name or last name)
-    - RECOMMENDED: Position (QB, RB, WR, TE, CB, DT, LB, etc.) AND/OR Team
-    - OPTIONAL: Additional context (draft info, accolades, role)
-    
-    **Extraction Guidelines:**
-    - If a player has BOTH name AND position/team → Extract with high confidence (0.85-1.0)
-    - If a player has ONLY a name but is prominent in context → Extract with medium confidence (0.70-0.85)
-    - Include position info from descriptors: "cornerback Sauce Gardner" → position: "CB"
-    - Include position from titles/roles: "All-Pro defensive tackle" → position: "DT"
-    - Look for team context throughout the text to associate players with teams
-    
-    **How to extract:**
-    - mention_text: Exact name as it appears (e.g., "Quinnen Williams", "Sauce Gardner", "Breece Hall")
-    - position: NFL position abbreviation (QB, RB, WR, TE, CB, DT, DE, LB, S, K, P, etc.)
-    - team_name: Full team name if mentioned or can be inferred (e.g., "New York Jets")
-    - team_abbr: Team abbreviation if known (e.g., "NYJ")
-    - context: Brief note about the player's role, accolades, or relevance (optional but helpful)
-    - confidence: 0.90-1.0 with position+team, 0.75-0.90 with position OR team, 0.70-0.80 name only
-    - rank: Importance ranking (1=primary/main subject, 2=important mention, 3+=minor mention)
-    - Only extract actual players as type "player". For coaches, general managers, and other non-player personnel, use type "staff".
-    
-    **Examples:**
-    ✅ "cornerback Sauce Gardner" → {{"type": "player", "mention_text": "Sauce Gardner", "position": "CB", "team_name": "New York Jets", "team_abbr": "NYJ", "context": "two-time All-Pro", "confidence": 0.95}}
-    ✅ "defensive tackle Quinnen Williams" → {{"type": "player", "mention_text": "Quinnen Williams", "position": "DT", "team_name": "New York Jets", "team_abbr": "NYJ", "context": "2022 All-Pro", "confidence": 0.95}}
-    ✅ "receiver Adonai Mitchell" → {{"type": "player", "mention_text": "Adonai Mitchell", "position": "WR", "confidence": 0.85}}
-    ✅ "Breece Hall" (mentioned as important player) → {{"type": "player", "mention_text": "Breece Hall", "team_name": "New York Jets", "team_abbr": "NYJ", "confidence": 0.80}}
-    ✅ "General Manager Darren Mougey" → {{"type": "staff", "mention_text": "Darren Mougey", "role": "General Manager", "team_name": "New York Jets", "team_abbr": "NYJ", "confidence": 0.85}}
-    **Why we extract with partial information:**
-    - "Quinnen Williams" appears with "defensive tackle" → We have name + position, extract it!
-    - Context mentions "Jets" earlier → We can infer team association
-    - Better to extract and let fuzzy matching resolve than to miss the entity entirely
+    For each entity include: type, mention_text, confidence (0-1), rank (1=primary, 2=secondary, 3+=minor).
+    - team: also include team_name (full), team_abbr (NFL abbr e.g. NYJ, KC, IND)
+    - player: also include position (QB/RB/WR/TE/CB/DT/DE/LB/S/K/P), team_name, team_abbr. Infer position/team from context when available.
+    - staff: also include role, team_name, team_abbr
+    - game: also include teams array, context (week/round)
 
-    ═══════════════════════════════════════════════════════════════════════════════
+    Extract with partial info rather than skip. Max {max_items} entities per fact.
 
-    **ENTITY TYPE 3: GAMES**
-    
-    **EXTRACT SPECIFIC GAME REFERENCES when matchups are clearly described.**
-    
-    Games require:
-    - Clear matchup between two teams
-    - Optional: Week, date, playoff round, or other identifying context
-    
-    **Examples:**
-    ✅ "Bills vs Chiefs Week 6" → {{"type": "game", "mention_text": "Bills vs Chiefs Week 6", "teams": ["Bills", "Chiefs"], "context": "Week 6", "confidence": 0.95}}
-    ✅ "Super Bowl LVIII" → {{"type": "game", "mention_text": "Super Bowl LVIII", "teams": [], "context": "Super Bowl LVIII", "confidence": 1.0}}
-    
-    ═══════════════════════════════════════════════════════════════════════════════
+    Return a JSON array with one object per fact, in order:
+    [{{"fact_index":1,"entities":[{{"type":"player","mention_text":"Josh Allen","position":"QB","team_abbr":"BUF","confidence":0.95,"rank":1}}]}},{{"fact_index":2,"entities":[]}}]
 
-    **EXTRACTION PROCESS:**
-    
-    1. **First Pass - Teams**: Identify ALL team mentions (full names, nicknames, contextual references)
-    2. **Second Pass - Players**: Identify ALL player names, then scan the text for position/team/context clues
-    3. **Third Pass - Games**: Identify any specific game matchups mentioned
-    4. **Fourth Pass - Cross-reference**: Link players to teams based on story context
-    5. **Fifth Pass - Ranking**: Assign rank based on prominence (1=main subject, 2=important, 3+=supporting)
-    6. **Final Check**: Have you extracted EVERY team and player mentioned? Review the text one more time.
-    
-    **RANKING SYSTEM:**
-    - Rank 1: Primary entities - the main subjects of the story (traded players, team making the move, etc.)
-    - Rank 2: Secondary entities - important supporting entities (receiving team, mentioned players)
-    - Rank 3+: Minor entities - mentioned but not central to the story
-    
-    ═══════════════════════════════════════════════════════════════════════════════
-
-    **OUTPUT FORMAT:**
-    
-    Return up to {max_items} entities in JSON format, **ORDERED BY RANK** (rank 1 first, then 2, then 3, etc.):
-    
-    {{
-      "entities": [
-        {{
-          "type": "team",
-          "mention_text": "New York Jets",
-          "team_name": "New York Jets",
-          "team_abbr": "NYJ",
-          "confidence": 1.0,
-          "rank": 1
-        }},
-        {{
-          "type": "player",
-          "mention_text": "Quinnen Williams",
-          "position": "DT",
-          "team_name": "New York Jets",
-          "team_abbr": "NYJ",
-          "context": "2022 All-Pro defensive tackle",
-          "confidence": 0.95,
-          "rank": 1
-        }},
-        {{
-          "type": "team",
-          "mention_text": "Indianapolis",
-          "team_name": "Indianapolis Colts",
-          "team_abbr": "IND",
-          "confidence": 0.90,
-          "rank": 2
-        }},
-        {{
-          "type": "player",
-          "mention_text": "Breece Hall",
-          "team_name": "New York Jets",
-          "team_abbr": "NYJ",
-          "confidence": 0.80,
-          "rank": 3
-        }}
-      ]
-    }}
-
-    ═══════════════════════════════════════════════════════════════════════════════
-
-    **STORY SUMMARY:**
-
-    {summary_text}
-
-    ═══════════════════════════════════════════════════════════════════════════════
-
-    **YOUR RESPONSE (JSON ONLY):**
-    
-    Before responding, ask yourself:
-    1. Did I extract EVERY team mentioned? (Check for full names, nicknames, city names)
-    2. Did I extract EVERY player mentioned? (Check for full names, last names, role descriptions)
-    3. Did I include as much disambiguation info as possible from the text?
-    4. Did I assign appropriate ranks (1=primary, 2=secondary, 3+=minor)?
-    5. Are entities ordered by rank in my response?
-    
-    Now provide your JSON response:
+    Facts:
+    {numbered_facts}
     """
 ).strip()
 
@@ -263,4 +72,18 @@ def build_entity_extraction_prompt(summary_text: str, max_entities: int) -> str:
     return ENTITY_EXTRACTION_PROMPT_TEMPLATE.format(
         summary_text=summary_text,
         max_items=max_entities,
+    )
+
+
+def build_batched_entity_extraction_prompt(
+    facts: list[str], max_entities_per_fact: int
+) -> str:
+    """Format the batched entity extraction prompt for multiple facts."""
+
+    numbered_facts = "\n".join(
+        f"{i+1}. {fact}" for i, fact in enumerate(facts)
+    )
+    return BATCHED_ENTITY_EXTRACTION_PROMPT_TEMPLATE.format(
+        numbered_facts=numbered_facts,
+        max_items=max_entities_per_fact,
     )

--- a/src/functions/knowledge_extraction/scripts/realtime_entities_worker.py
+++ b/src/functions/knowledge_extraction/scripts/realtime_entities_worker.py
@@ -247,34 +247,41 @@ def main() -> None:
         if row.get("news_fact_id")
     }
 
-    for row in pending_facts:
-        fact_id = row["id"]
-        if fact_id in existing_fact_ids:
-            stats["skipped_existing"] += 1
-            continue
+    # Filter out already-existing facts
+    facts_to_process = [
+        row for row in pending_facts if row["id"] not in existing_fact_ids
+    ]
+    stats["skipped_existing"] = len(pending_facts) - len(facts_to_process)
 
-        try:
-            extracted = extractor.extract(
-                row["fact_text"],
-                max_entities=args.max_entities,
-            )
-            resolved = resolve_entities(extracted, resolver)
-            if not resolved:
-                resolved = [build_no_entity_marker()]
-                stats["skipped_no_data"] += 1
+    # Use batched multi-fact extraction (Phase 3 optimization)
+    if facts_to_process:
+        multi_results = extractor.extract_multi(
+            facts_to_process,
+            max_entities_per_fact=args.max_entities,
+            chunk_size=15,
+        )
 
-            written = writer.write_fact_entities(
-                news_fact_id=fact_id,
-                entities=resolved,
-                llm_model=args.model,
-                dry_run=args.dry_run,
-            )
-            stats["entities_written"] += written
-            stats["processed"] += 1
-            processed_fact_ids.append(fact_id)
-        except Exception as exc:
-            stats["failed"] += 1
-            logger.error("Realtime entities failed for %s: %s", fact_id, exc, exc_info=True)
+        for row in facts_to_process:
+            fact_id = row["id"]
+            try:
+                extracted = multi_results.get(fact_id, [])
+                resolved = resolve_entities(extracted, resolver)
+                if not resolved:
+                    resolved = [build_no_entity_marker()]
+                    stats["skipped_no_data"] += 1
+
+                written = writer.write_fact_entities(
+                    news_fact_id=fact_id,
+                    entities=resolved,
+                    llm_model=args.model,
+                    dry_run=args.dry_run,
+                )
+                stats["entities_written"] += written
+                stats["processed"] += 1
+                processed_fact_ids.append(fact_id)
+            except Exception as exc:
+                stats["failed"] += 1
+                logger.error("Realtime entities failed for %s: %s", fact_id, exc, exc_info=True)
 
     if processed_fact_ids:
         stats["urls_completed"] = completion_tracker.mark_complete_for_fact_ids(


### PR DESCRIPTION
## Summary
- **Phase 1:** Drop reasoning effort from `"medium"` to `"low"` on entity/topic extractors and batch request generator; reduce realtime cron from `*/5` to `*/15` minutes (~50-65% savings)
- **Phase 2:** Compress entity extraction prompt from ~1,500 to ~100 words and topic extraction prompt from ~500 to ~130 words (~15-20% additional savings)
- **Phase 3:** Add batched multi-fact entity extraction (`extract_multi`) that sends 15 facts per API call instead of 250 individual calls, cutting prompt overhead by ~96% (~20-25% additional savings)
- **Phase 4:** Tighten `max_completion_tokens` on summary batch from 4000 to 2000

Projected daily token usage: **22M → ~3-5M tokens/day**

## Files changed (7)
- `src/functions/knowledge_extraction/core/extraction/entity_extractor.py` — reasoning `"low"` + new `extract_multi()` method
- `src/functions/knowledge_extraction/core/extraction/topic_extractor.py` — reasoning `"low"`
- `src/functions/knowledge_extraction/core/batch/request_generator.py` — reasoning + verbosity `"low"`
- `src/functions/knowledge_extraction/core/prompts.py` — compressed prompts + new batched prompt template
- `src/functions/knowledge_extraction/scripts/realtime_entities_worker.py` — refactored to use `extract_multi()`
- `src/functions/content_summarization/core/summary_batch/request_generator.py` — max_completion_tokens 4000 → 2000
- `.github/workflows/content-facts-entities-realtime.yml` — cron `*/5` → `*/15`

## Test plan
- [ ] Verify existing tests pass (14/14 passing; 6 pre-existing failures unrelated to this PR)
- [ ] Monitor OpenAI dashboard for token usage drop after merge (expect ~50% immediate from Phase 1)
- [ ] Spot-check entity/topic extraction quality on 50-100 facts to confirm no regression from compressed prompts
- [ ] Monitor pipeline stats (entities_written, facts_processed) over 24h to ensure no throughput regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)