### PR TITLE
perf(url-content-extraction): phase 4 — browser reuse + shared HTTP client

### DIFF
--- a/src/functions/url_content_extraction/core/extractors/light_extractor.py
+++ b/src/functions/url_content_extraction/core/extractors/light_extractor.py
@@ -1,9 +1,15 @@
-"""HTTP-only extractor implementation using httpx and BeautifulSoup."""
+"""HTTP-only extractor implementation using httpx and BeautifulSoup.
+
+Uses a module-level ``httpx.Client`` so connection pooling, DNS caching,
+and TLS session resumption amortize across all ``LightExtractor`` calls in
+the same process. ``httpx.Client`` is thread-safe, so a single shared
+instance works fine for the ThreadPoolExecutor callers.
+"""
 
 from __future__ import annotations
 
-import asyncio
 import logging
+import threading
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -18,17 +24,59 @@ from ..processors.text_deduplicator import deduplicate_paragraphs
 from ..utils import amp_detector
 
 
+_DEFAULT_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_4) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/119.0.0.0 Safari/537.36"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+# Module-level shared client. Lazy-initialized, protected by a lock for
+# correctness under concurrent first-access. Lifetime is process-scope.
+_shared_client: Optional[httpx.Client] = None
+_shared_client_lock = threading.Lock()
+
+
+def _get_shared_client() -> httpx.Client:
+    global _shared_client
+    client = _shared_client
+    if client is not None:
+        return client
+    with _shared_client_lock:
+        if _shared_client is None:
+            _shared_client = httpx.Client(
+                headers=_DEFAULT_HEADERS,
+                follow_redirects=True,
+                # Reasonable default; per-call timeout is applied on .get() below.
+                timeout=30.0,
+                http2=True,
+                # Bound connection pool so a single pipeline run can't exhaust
+                # local file descriptors under high concurrency.
+                limits=httpx.Limits(
+                    max_connections=50, max_keepalive_connections=20
+                ),
+            )
+        return _shared_client
+
+
+def close_shared_client() -> None:
+    """Close the process-wide client (call at shutdown in long-running jobs)."""
+    global _shared_client
+    with _shared_client_lock:
+        if _shared_client is not None:
+            try:
+                _shared_client.close()
+            except Exception:
+                pass
+            _shared_client = None
+
+
 class LightExtractor:
     """Performs fast HTTP extraction for simple pages."""
 
-    _DEFAULT_HEADERS = {
-        "User-Agent": (
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_4) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/119.0.0.0 Safari/537.36"
-        ),
-        "Accept-Language": "en-US,en;q=0.9",
-    }
+    _DEFAULT_HEADERS = _DEFAULT_HEADERS  # Kept for back-compat imports.
 
     def __init__(self, *, logger: Optional[logging.Logger] = None) -> None:
         self._logger = logger or logging.getLogger(__name__)
@@ -46,42 +94,26 @@ class LightExtractor:
         if options:
             merged.update(options if isinstance(options, dict) else options.model_dump())
         validated = parse_options(merged)
-        return self._run_sync(validated)
+        return self._extract(validated)
 
-    def _run_sync(self, options: ExtractionOptions) -> ExtractedContent:
-        """Execute async extraction synchronously, handling existing event loops."""
-        # Check if we're already in an event loop
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # No running loop - safe to use asyncio.run()
-            return asyncio.run(self._extract(options))
-        
-        # Running loop exists - create and use a new one in a thread-safe way
-        import concurrent.futures
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(asyncio.run, self._extract(options))
-            return future.result(timeout=options.timeout_seconds + 10)
-
-    async def _fetch(self, options: ExtractionOptions) -> tuple[str, str]:
-        async with httpx.AsyncClient(headers=self._DEFAULT_HEADERS, follow_redirects=True, timeout=options.timeout_seconds) as client:
-            response = await client.get(str(options.url))
+    def _fetch(self, options: ExtractionOptions) -> tuple[str, str]:
+        client = _get_shared_client()
+        response = client.get(str(options.url), timeout=options.timeout_seconds)
+        response.raise_for_status()
+        html = response.text
+        amp_alternate = amp_detector.find_amp_alternate(html, str(options.url))
+        if amp_alternate:
+            self._logger.debug("Discovered AMP alternate for %s", options.url)
+            response = client.get(amp_alternate, timeout=options.timeout_seconds)
             response.raise_for_status()
-            html = response.text
-            amp_alternate = amp_detector.find_amp_alternate(html, str(options.url))
-            if amp_alternate:
-                self._logger.debug("Discovered AMP alternate for %s", options.url)
-                response = await client.get(amp_alternate)
-                response.raise_for_status()
-                html = response.text
-                return amp_alternate, html
-            return str(options.url), html
+            return amp_alternate, response.text
+        return str(options.url), html
 
-    async def _extract(self, options: ExtractionOptions) -> ExtractedContent:
+    def _extract(self, options: ExtractionOptions) -> ExtractedContent:
         start = time.perf_counter()
         self._logger.debug("Starting lightweight extraction for %s", options.url)
         try:
-            target_url, html = await self._fetch(options)
+            target_url, html = self._fetch(options)
         except httpx.HTTPError as exc:
             self._logger.warning("HTTP extraction failed for %s: %s", options.url, exc)
             return ExtractedContent(url=str(options.url), error=str(exc))

--- a/src/functions/url_content_extraction/core/extractors/playwright_extractor.py
+++ b/src/functions/url_content_extraction/core/extractors/playwright_extractor.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, Iterable, List, Optional, Sequence
 
 from bs4 import BeautifulSoup
 
@@ -105,217 +105,249 @@ class PlaywrightExtractor:
         return self._run_sync(validated)
 
     def _run_sync(self, options: ExtractionOptions) -> ExtractedContent:
-        """Execute async extraction synchronously, handling existing event loops."""
-        # Check if we're already in an event loop
+        """Run a single-URL async extraction synchronously."""
+        return self._run_async(self._extract(options), options.timeout_seconds + 10)
+
+    def _run_async(self, coro, timeout_seconds: float):
+        """Execute an async coroutine synchronously, even if a loop is running.
+
+        When no loop is running (typical CLI / Cloud Function path) we use
+        ``asyncio.run`` directly. When a loop is already running (e.g. test
+        harness) we spin a fresh loop on a worker thread so the extraction
+        doesn't try to reuse the caller's loop.
+        """
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
         except RuntimeError:
-            # No running loop - safe to use asyncio.run()
-            return asyncio.run(self._extract(options))
-        
-        # Running loop exists - create and use a new one in a thread-safe way
+            return asyncio.run(coro)
+
         import concurrent.futures
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(asyncio.run, self._extract(options))
-            return future.result(timeout=options.timeout_seconds + 10)
+            future = executor.submit(asyncio.run, coro)
+            return future.result(timeout=timeout_seconds)
+
+    # ------------------------------------------------------------------
+    # Batch API — reuses browser + context across URLs (biggest perf win)
+    # ------------------------------------------------------------------
+
+    def extract_many(
+        self,
+        urls: Sequence[str],
+        *,
+        timeout: Optional[float] = None,
+        options: dict | ExtractionOptions | None = None,
+    ) -> List[ExtractedContent]:
+        """Extract multiple URLs with a single browser + context instance.
+
+        Launching Chromium costs ~2-3s per URL; reusing the browser across a
+        batch amortizes that cost to once per batch. Yields results in the
+        same order as ``urls``. Failures on individual URLs are returned as
+        ``ExtractedContent(error=...)`` rather than raised.
+        """
+        url_list = [str(u) for u in urls]
+        if not url_list:
+            return []
+
+        option_sets: List[ExtractionOptions] = []
+        for url in url_list:
+            merged_options: dict[str, object] = {"url": url}
+            if timeout:
+                merged_options["timeout_seconds"] = int(timeout)
+            if options:
+                merged_options.update(
+                    options if isinstance(options, dict) else options.model_dump()
+                )
+            option_sets.append(parse_options(merged_options))
+
+        total_timeout = sum(opt.timeout_seconds for opt in option_sets) + 30
+        return self._run_async(self._extract_batch(option_sets), total_timeout)
+
+    async def _extract_batch(
+        self, option_sets: List[ExtractionOptions]
+    ) -> List[ExtractedContent]:
+        if async_playwright is None:  # pragma: no cover - optional dep missing
+            return [
+                ExtractedContent(
+                    url=str(opt.url),
+                    error="Playwright is not available in the current environment",
+                )
+                for opt in option_sets
+            ]
+
+        results: List[ExtractedContent] = []
+        async with async_playwright() as playwright:
+            browser = await self._launch_browser(playwright)
+            try:
+                context = await self._new_context(browser)
+                try:
+                    for opts in option_sets:
+                        context.set_default_navigation_timeout(
+                            opts.timeout_seconds * 1000
+                        )
+                        results.append(await self._extract_one(context, opts))
+                finally:
+                    await context.close()
+            finally:
+                await browser.close()
+        return results
+
+    # ------------------------------------------------------------------
+    # Single-URL extraction (unchanged API, now routed through shared helpers)
+    # ------------------------------------------------------------------
 
     async def _extract(self, options: ExtractionOptions) -> ExtractedContent:
+        """Single-URL extraction (browser lifecycle scoped to one URL)."""
+        if async_playwright is None:
+            return ExtractedContent(
+                url=str(options.url),
+                error="Playwright is not available in the current environment",
+            )
+
+        async with async_playwright() as playwright:
+            browser = await self._launch_browser(playwright)
+            try:
+                context = await self._new_context(browser)
+                context.set_default_navigation_timeout(options.timeout_seconds * 1000)
+                try:
+                    return await self._extract_one(context, options)
+                finally:
+                    await context.close()
+            finally:
+                await browser.close()
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+
+    async def _launch_browser(self, playwright):
+        return await playwright.chromium.launch(
+            headless=True,
+            args=self._STEALTH_ARGS,
+            channel=None,  # Use bundled Chromium
+        )
+
+    async def _new_context(self, browser):
+        context = await browser.new_context(
+            user_agent=self._USER_AGENT,
+            locale="en-US",
+            timezone_id="America/New_York",
+            ignore_https_errors=True,
+            viewport={"width": 1920, "height": 1080},
+            screen={"width": 1920, "height": 1080},
+            device_scale_factor=1,
+            has_touch=False,
+            is_mobile=False,
+            extra_http_headers={
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Upgrade-Insecure-Requests": "1",
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "none",
+                "Sec-Fetch-User": "?1",
+                "Cache-Control": "max-age=0",
+            },
+        )
+        await context.add_init_script(self._ANTI_DETECTION_SCRIPT)
+        return context
+
+    async def _extract_one(
+        self, context, options: ExtractionOptions
+    ) -> ExtractedContent:
+        """Open a page, extract one URL, close the page. Never raises."""
         start = time.perf_counter()
         self._logger.debug("Starting Playwright extraction for %s", options.url)
         page = None
-        context = None
-        browser = None
-        
+        html = ""
         try:
-            if async_playwright is None:
-                msg = "Playwright is not available in the current environment"
-                raise RuntimeError(msg)
-            
-            async with async_playwright() as playwright:
-                browser = await playwright.chromium.launch(
-                    headless=True, 
-                    args=self._STEALTH_ARGS,
-                    channel=None  # Use bundled Chromium
-                )
-                context = await browser.new_context(
-                    user_agent=self._USER_AGENT,
-                    locale="en-US",
-                    timezone_id="America/New_York",
-                    ignore_https_errors=True,
-                    viewport={"width": 1920, "height": 1080},
-                    screen={"width": 1920, "height": 1080},
-                    device_scale_factor=1,
-                    has_touch=False,
-                    is_mobile=False,
-                    extra_http_headers={
-                        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-                        "Accept-Language": "en-US,en;q=0.9",
-                        "Accept-Encoding": "gzip, deflate, br",
-                        "Upgrade-Insecure-Requests": "1",
-                        "Sec-Fetch-Dest": "document",
-                        "Sec-Fetch-Mode": "navigate",
-                        "Sec-Fetch-Site": "none",
-                        "Sec-Fetch-User": "?1",
-                        "Cache-Control": "max-age=0",
-                    },
-                )
-                
-                # Enhanced anti-detection script
-                await context.add_init_script("""
-                    // Remove webdriver property
-                    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
-                    
-                    // Add chrome object
-                    window.chrome = {
-                        runtime: {},
-                        loadTimes: function() {},
-                        csi: function() {},
-                        app: {}
-                    };
-                    
-                    // Override permissions
-                    const originalQuery = window.navigator.permissions.query;
-                    window.navigator.permissions.query = (parameters) => (
-                        parameters.name === 'notifications' ?
-                            Promise.resolve({ state: Notification.permission }) :
-                            originalQuery(parameters)
-                    );
-                    
-                    // Add realistic properties
-                    Object.defineProperty(navigator, 'platform', { get: () => 'MacIntel' });
-                    Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'] });
-                    Object.defineProperty(navigator, 'vendor', { get: () => 'Google Inc.' });
-                    Object.defineProperty(navigator, 'hardwareConcurrency', { get: () => 8 });
-                    Object.defineProperty(navigator, 'deviceMemory', { get: () => 8 });
-                    
-                    // Add plugins
-                    Object.defineProperty(navigator, 'plugins', {
-                        get: () => [
-                            { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
-                            { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai', description: '' },
-                            { name: 'Native Client', filename: 'internal-nacl-plugin', description: '' }
-                        ]
-                    });
-                    
-                    // Override automation-related properties
-                    delete navigator.__proto__.webdriver;
-                    
-                    // Add realistic connection info
-                    Object.defineProperty(navigator, 'connection', {
-                        get: () => ({
-                            effectiveType: '4g',
-                            rtt: 50,
-                            downlink: 10,
-                            saveData: false
-                        })
-                    });
-                """)
-                
-                context.set_default_navigation_timeout(options.timeout_seconds * 1000)
-                page = await context.new_page()
-                
-                await self._navigate(page, str(options.url), options)
-                
-                # Wait for DOM and do scrolling to trigger lazy content
+            page = await context.new_page()
+            await self._navigate(page, str(options.url), options)
+
+            try:
+                await page.wait_for_load_state("domcontentloaded", timeout=10000)
+            except PlaywrightTimeoutError:
+                pass
+
+            await consent_handler.solve_consent(page, logger=self._logger)
+            await page.wait_for_timeout(500)
+
+            # Gated scroll: only hosts that lazy-render articles pay the
+            # ~1-2s scroll cost.
+            from .extractor_factory import is_heavy_url
+
+            if is_heavy_url(str(options.url)):
                 try:
-                    await page.wait_for_load_state("domcontentloaded", timeout=10000)
+                    for _ in range(3):
+                        await page.mouse.wheel(0, 800)
+                        await page.wait_for_timeout(250)
+                except PlaywrightError:
+                    pass
+
+            url_lower = str(options.url).lower()
+            if "espn.com" in url_lower or "nbcsports" in url_lower:
+                self._logger.debug("JS-heavy host detected — waiting 3s")
+                await page.wait_for_timeout(3000)
+
+            html = await page.content()
+
+            # Follow AMP alternate if present (and we're not already on AMP).
+            amp_target = amp_detector.find_amp_alternate(html, str(options.url))
+            if amp_target and not amp_detector.is_amp_url(str(options.url)):
+                self._logger.debug("Following AMP link for %s", options.url)
+                await self._navigate(page, amp_target, options)
+                try:
+                    await page.wait_for_load_state("domcontentloaded", timeout=5000)
                 except PlaywrightTimeoutError:
                     pass
-                
-                # Handle consent dialogs BEFORE extracting content
+                try:
+                    await page.mouse.wheel(0, 500)
+                    await page.wait_for_timeout(300)
+                except PlaywrightError:
+                    pass
                 await consent_handler.solve_consent(page, logger=self._logger)
-                
-                # Wait a bit for consent dialog to be dismissed and page to reflow
-                await page.wait_for_timeout(500)
-                
-                # Scroll to trigger lazy-loaded content — only on hosts known
-                # to lazy-render articles. For everyone else the unconditional
-                # 3×800px + 3×250ms dance added ~1-2s per URL for no gain.
-                from .extractor_factory import is_heavy_url
-
-                host_is_heavy = is_heavy_url(str(options.url))
-                if host_is_heavy:
-                    try:
-                        for _ in range(3):
-                            await page.mouse.wheel(0, 800)
-                            await page.wait_for_timeout(250)
-                    except PlaywrightError:
-                        pass
-                
-                # Give ESPN's JavaScript time to populate content
-                is_espn = "espn.com" in str(options.url).lower()
-                is_nbc_sports = "nbcsports" in str(options.url).lower()
-                if is_espn or is_nbc_sports:
-                    self._logger.debug("Detected %s - waiting for JS content", "ESPN" if is_espn else "NBC Sports")
-                    await page.wait_for_timeout(3000)  # Longer wait for JS-heavy sites
-                
                 html = await page.content()
-                
-                # Check for AMP
-                amp_target = amp_detector.find_amp_alternate(html, str(options.url))
-                if amp_target and not amp_detector.is_amp_url(str(options.url)):
-                    self._logger.debug("Following AMP link for %s", options.url)
-                    await self._navigate(page, amp_target, options)
-                    
-                    # Wait for AMP page to load
-                    try:
-                        await page.wait_for_load_state("domcontentloaded", timeout=5000)
-                    except PlaywrightTimeoutError:
-                        pass
-                    
-                    # Small scroll to trigger any lazy content on AMP page
-                    try:
-                        await page.mouse.wheel(0, 500)
-                        await page.wait_for_timeout(300)
-                    except PlaywrightError:
-                        pass
-                    
-                    # Handle consent on AMP page (critical for EU news sites with AMP mirrors)
-                    await consent_handler.solve_consent(page, logger=self._logger)
-                    
-                    html = await page.content()
-                
-                # Try tree walker extraction (most robust for ESPN)
-                tree_paragraphs = await self._extract_with_tree_walker(page)
-                if tree_paragraphs and len(tree_paragraphs) >= 3:
-                    self._logger.debug("Tree walker found %d paragraphs", len(tree_paragraphs))
-                    html = await page.content()
-                    content = self._parse_html(html, page.url)
-                    content.paragraphs = tree_paragraphs
-                else:
-                    # If content still insufficient, do one more scroll nudge
-                    self._logger.debug("Tree walker found insufficient content (%d paragraphs), trying final scroll", len(tree_paragraphs) if tree_paragraphs else 0)
-                    for _ in range(2):
-                        await page.mouse.wheel(0, 1000)
-                        await page.wait_for_timeout(300)
-                    
-                    html = await page.content()
-                    content = self._parse_html(html, page.url)
-                    
-                    # Final fallback to tree walker
-                    if not content.paragraphs or len(content.paragraphs) < 2:
-                        tree_paragraphs = await self._extract_with_tree_walker(page)
-                        if tree_paragraphs:
-                            content.paragraphs = tree_paragraphs
-                
-                # Clean up before exiting context
-                await page.close()
-                await context.close()
-                await browser.close()
-                
+
+            # Primary: JS tree-walker (most robust on JS-heavy sites).
+            tree_paragraphs = await self._extract_with_tree_walker(page)
+            if tree_paragraphs and len(tree_paragraphs) >= 3:
+                self._logger.debug(
+                    "Tree walker found %d paragraphs", len(tree_paragraphs)
+                )
+                html = await page.content()
+                content = self._parse_html(html, page.url)
+                content.paragraphs = tree_paragraphs
+            else:
+                # Last-chance scroll nudge, then re-parse.
+                self._logger.debug(
+                    "Tree walker insufficient (%d paragraphs); final scroll",
+                    len(tree_paragraphs) if tree_paragraphs else 0,
+                )
+                for _ in range(2):
+                    await page.mouse.wheel(0, 1000)
+                    await page.wait_for_timeout(300)
+                html = await page.content()
+                content = self._parse_html(html, page.url)
+                if not content.paragraphs or len(content.paragraphs) < 2:
+                    tree_paragraphs = await self._extract_with_tree_walker(page)
+                    if tree_paragraphs:
+                        content.paragraphs = tree_paragraphs
         except Exception as exc:  # pragma: no cover - defensive umbrella
-            self._logger.exception("Playwright extraction failed for %s", options.url)
-            # Clean up on error
-            try:
-                if page:
+            self._logger.exception(
+                "Playwright extraction failed for %s", options.url
+            )
+            if page is not None:
+                try:
                     await page.close()
-                if context:
-                    await context.close()
-                if browser:
-                    await browser.close()
-            except Exception:
-                self._logger.debug("Cleanup error after extraction failure", exc_info=True)
+                except Exception:
+                    self._logger.debug("Page close error", exc_info=True)
             return ExtractedContent(url=str(options.url), error=str(exc))
+
+        try:
+            await page.close()
+        except Exception:
+            self._logger.debug("Page close error", exc_info=True)
 
         elapsed = time.perf_counter() - start
         metadata = content.metadata or ExtractionMetadata(
@@ -335,6 +367,54 @@ class PlaywrightExtractor:
         if not content.is_valid():
             content.error = content.error or "Insufficient content extracted"
         return content
+
+    # Anti-detection init script (shared across all contexts).
+    _ANTI_DETECTION_SCRIPT = """
+        // Remove webdriver property
+        Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+
+        // Add chrome object
+        window.chrome = {
+            runtime: {},
+            loadTimes: function() {},
+            csi: function() {},
+            app: {}
+        };
+
+        // Override permissions
+        const originalQuery = window.navigator.permissions.query;
+        window.navigator.permissions.query = (parameters) => (
+            parameters.name === 'notifications' ?
+                Promise.resolve({ state: Notification.permission }) :
+                originalQuery(parameters)
+        );
+
+        // Add realistic properties
+        Object.defineProperty(navigator, 'platform', { get: () => 'MacIntel' });
+        Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'] });
+        Object.defineProperty(navigator, 'vendor', { get: () => 'Google Inc.' });
+        Object.defineProperty(navigator, 'hardwareConcurrency', { get: () => 8 });
+        Object.defineProperty(navigator, 'deviceMemory', { get: () => 8 });
+
+        Object.defineProperty(navigator, 'plugins', {
+            get: () => [
+                { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
+                { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai', description: '' },
+                { name: 'Native Client', filename: 'internal-nacl-plugin', description: '' }
+            ]
+        });
+
+        delete navigator.__proto__.webdriver;
+
+        Object.defineProperty(navigator, 'connection', {
+            get: () => ({
+                effectiveType: '4g',
+                rtt: 50,
+                downlink: 10,
+                saveData: false
+            })
+        });
+    """
 
     async def _navigate(self, page: Any, url: str, options: ExtractionOptions) -> None:
         try:

--- a/src/functions/url_content_extraction/scripts/content_batch_processor.py
+++ b/src/functions/url_content_extraction/scripts/content_batch_processor.py
@@ -143,6 +143,51 @@ def fetch_pending_urls(
         return all_urls
 
 
+def _batch_extract_heavy(
+    items: List[Dict[str, Any]],
+    *,
+    timeout: int = 45,
+) -> Dict[str, str]:
+    """Extract heavy (Playwright) URLs using one shared browser.
+
+    Launching Chromium costs ~2-3s per URL; reusing the browser across the
+    whole batch amortizes that to a single launch. Returns a ``{url_id:
+    content}`` map. Items with extraction errors are omitted so the
+    downstream per-URL path handles them through the standard failure flow.
+    """
+    if not items:
+        return {}
+
+    from src.functions.url_content_extraction.core.extractors.playwright_extractor import (
+        PlaywrightExtractor,
+    )
+
+    urls = [str(item.get("url", "")) for item in items]
+    extractor = PlaywrightExtractor(logger=logger)
+    try:
+        results = extractor.extract_many(urls, timeout=timeout)
+    except Exception as exc:
+        logger.warning(
+            "Shared Playwright batch failed (%s); falling back to per-URL extraction",
+            exc,
+        )
+        return {}
+
+    content_by_id: Dict[str, str] = {}
+    for item, result in zip(items, results):
+        url_id = str(item.get("id", ""))
+        if not url_id:
+            continue
+        if result.error:
+            logger.warning(
+                "Batched extraction error for %s: %s", url_id, result.error
+            )
+            continue
+        if result.paragraphs:
+            content_by_id[url_id] = "\n\n".join(result.paragraphs).strip()
+    return content_by_id
+
+
 def extract_content(url: str, timeout: int = 45) -> str:
     """Extract article content from URL.
     
@@ -250,18 +295,14 @@ def process_url(
     failure_tracker: FailureTracker,
     timeout: int = 45,
     max_attempts: int = 3,
+    *,
+    prefetched_content: Optional[str] = None,
 ) -> bool:
     """Process a single URL for content extraction.
-    
-    Args:
-        item: URL record with id and url
-        client: Supabase client
-        checkpoint: Checkpoint manager
-        failure_tracker: Failure tracker
-        timeout: Request timeout
-        
-    Returns:
-        True if successful
+
+    ``prefetched_content`` lets the batched heavy-URL path hand in content
+    that was already extracted via a shared Playwright browser, skipping the
+    per-URL Chromium startup cost.
     """
     url_id = str(item.get("id", ""))
     url = item.get("url", "")
@@ -281,8 +322,8 @@ def process_url(
         return False
 
     try:
-        # Extract content
-        content = extract_content(url, timeout=timeout)
+        # Extract content (or use the batched result when present)
+        content = prefetched_content if prefetched_content is not None else extract_content(url, timeout=timeout)
 
         if not content:
             register_stage_failure(
@@ -419,7 +460,7 @@ def run_batch_processor(
         failed = 0
         successful_url_ids: List[str] = []
 
-        def process_and_track(item):
+        def process_and_track(item, *, prefetched_content: str | None = None):
             """Process a URL and return success status."""
             nonlocal successful, failed
             try:
@@ -430,6 +471,7 @@ def run_batch_processor(
                     failure_tracker,
                     timeout,
                     max_attempts,
+                    prefetched_content=prefetched_content,
                 )
                 if success:
                     successful += 1
@@ -488,17 +530,30 @@ def run_batch_processor(
                     if progress.should_log():
                         progress.log_progress(extra_stats=memory_monitor.get_stats())
 
-        # Process heavy URLs sequentially (Playwright not thread-safe)
+        # Process heavy URLs in a single Playwright batch so we launch
+        # Chromium once per run instead of once per URL (~2-3s saved per URL).
         if heavy_urls:
-            logger.info("Processing %d heavy URLs sequentially (Playwright)...", len(heavy_urls))
+            logger.info(
+                "Processing %d heavy URLs via shared Playwright browser...",
+                len(heavy_urls),
+            )
+            # Pre-extract all heavy URLs in one batch (browser launched once).
+            pending_items = [
+                item
+                for item in heavy_urls
+                if not checkpoint.is_stage_complete(str(item.get("id", "")), "content")
+                and not failure_tracker.is_skipped("content", str(item.get("id", "")))
+            ]
+            content_by_id = _batch_extract_heavy(pending_items, timeout=timeout)
+
             for item in heavy_urls:
-                process_and_track(item)
-                
-                # Periodic checkpoint flush
+                url_id = str(item.get("id", ""))
+                # Feed the already-fetched content into the normal per-URL path.
+                prefetched = content_by_id.get(url_id)
+                process_and_track(item, prefetched_content=prefetched)
+
                 if progress.processed_count % flush_interval == 0:
                     checkpoint.flush()
-
-                # Log progress
                 if progress.should_log():
                     progress.log_progress(extra_stats=memory_monitor.get_stats())
 

--- a/tests/url_content_extraction/test_regressions.py
+++ b/tests/url_content_extraction/test_regressions.py
@@ -242,6 +242,94 @@ def test_handle_request_raises_become_per_url_errors(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Phase 4: Playwright browser reuse (3.1) + LightExtractor shared client (3.2)
+# ---------------------------------------------------------------------------
+
+
+def test_playwright_extractor_exposes_extract_many():
+    """`extract_many` must exist on PlaywrightExtractor and accept a URL list."""
+    from src.functions.url_content_extraction.core.extractors.playwright_extractor import (
+        PlaywrightExtractor,
+    )
+
+    extractor = PlaywrightExtractor()
+    assert callable(getattr(extractor, "extract_many", None))
+    # Empty input is a defined no-op (returns []) — no browser launch.
+    assert extractor.extract_many([]) == []
+
+
+def test_playwright_extract_many_reuses_browser(monkeypatch):
+    """`extract_many` must launch the browser exactly once for N URLs."""
+    from src.functions.url_content_extraction.core.extractors import playwright_extractor as pe
+
+    launches: list[str] = []
+    contexts: list[str] = []
+    pages_per_context: list[int] = []
+
+    class FakePage:
+        def __init__(self, ctx): self.ctx = ctx; self.url = "about:blank"
+        async def close(self): pass
+
+    class FakeContext:
+        def __init__(self):
+            contexts.append("new")
+            pages_per_context.append(0)
+        def set_default_navigation_timeout(self, _): pass
+        async def new_page(self):
+            pages_per_context[-1] += 1
+            return FakePage(self)
+        async def close(self): pass
+        async def add_init_script(self, _): pass
+
+    class FakeBrowser:
+        async def new_context(self, **_kwargs):
+            return FakeContext()
+        async def close(self): pass
+
+    class FakePlaywright:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+        @property
+        def chromium(self): return self
+        async def launch(self, **_kwargs):
+            launches.append("launch")
+            return FakeBrowser()
+
+    def _fake_playwright(): return FakePlaywright()
+
+    async def _fake_extract_one(self, context, options):
+        from src.functions.url_content_extraction.core.contracts.extracted_content import (
+            ExtractedContent,
+        )
+        return ExtractedContent(url=str(options.url), paragraphs=["ok"])
+
+    monkeypatch.setattr(pe, "async_playwright", _fake_playwright)
+    monkeypatch.setattr(pe.PlaywrightExtractor, "_extract_one", _fake_extract_one)
+
+    extractor = pe.PlaywrightExtractor()
+    results = extractor.extract_many(
+        ["https://example.com/a", "https://example.com/b", "https://example.com/c"]
+    )
+    assert len(results) == 3
+    assert all(r.paragraphs == ["ok"] for r in results)
+    # Single browser launch + single context shared across all URLs.
+    assert len(launches) == 1
+    assert len(contexts) == 1
+
+
+def test_light_extractor_uses_shared_httpx_client():
+    """All LightExtractor calls must resolve to the same `httpx.Client`."""
+    from src.functions.url_content_extraction.core.extractors import light_extractor
+
+    # Reset and then force two accesses; both should return the same instance.
+    light_extractor.close_shared_client()
+    c1 = light_extractor._get_shared_client()
+    c2 = light_extractor._get_shared_client()
+    assert c1 is c2
+    light_extractor.close_shared_client()
+
+
+# ---------------------------------------------------------------------------
 # FactsWriter / FactsReader (Phase 3: core/db consolidation)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the final two deferred perf items from PR #120. Completes the `url_content_extraction` refactor arc started in PR #119.

**Base branch: \`refactor/url-content-extraction-phase-3\`** (stacked on PR #121). Retarget to \`main\` or an upstream branch as earlier PRs merge.

**Net: +511 / -256 across 4 files. 31/31 tests passing.**

## 3.1 — Playwright browser reuse across URLs

\`PlaywrightExtractor.extract_many(urls, ...)\` launches Chromium once and walks the URL list on a shared browser + context, closing one page per URL. The single-URL \`extract()\` API is preserved and now routes through the same \`_extract_one\` helper (browser lifecycle still scoped per call in that mode).

\`content_batch_processor\`'s heavy-URL loop pre-extracts the whole batch via \`extract_many\` and feeds the content through the existing per-URL \`process_url\` path via a new \`prefetched_content\` kwarg. Net effect: **one Chromium launch per run instead of one per heavy URL** (~2–3 s saved per URL in the nominal case).

**Safety**: per-URL errors in a batch surface as \`ExtractedContent(error=...)\` and fall through to the standard per-URL failure tracking. A complete batch failure is caught and logs a warning, so the downstream path still runs with per-URL extraction as a fallback.

## 3.2 — Shared \`httpx.Client\` in \`LightExtractor\`

\`LightExtractor\` is now purely sync and uses a module-level \`httpx.Client\` (lazy-initialized, thread-safe lock) so connection pooling, DNS caching, and TLS session resumption amortize across every light extraction in the process. Also removes the \`asyncio.run\` / \`ThreadPoolExecutor\` dance the async body used to need.

Pool limits: 50 total connections / 20 keepalive to bound file descriptors under concurrent pipelines. \`close_shared_client()\` is exposed for long-running jobs that want to be explicit at shutdown; most callers can rely on process exit.

## New tests (3)

- \`extract_many\` is a no-op on empty input (no browser launched)
- \`extract_many\` launches the browser **exactly once** across multiple URLs (the invariant the whole refactor exists to preserve)
- \`LightExtractor\`'s shared \`httpx.Client\` is a true singleton across accesses

## Stack status

- **#119** Phase A+B → \`main\`
- **#120** Phase 2: tests + quality + perf → #119
- **#121** Phase 3: DB layer consolidation → #120
- **#122** Phase 4: browser reuse + shared HTTP client → #121 ← **this PR**

All deferred items from the original code-excellence review are now addressed. Remaining work (not in scope for this arc):
- Migrate \`scripts/extract_facts_cli.py\` from \`core/facts/storage.py\` to the new \`FactsWriter\` (low-risk cleanup, CLI path only).

## Test plan

- [x] \`pytest tests/url_content_extraction\` — 22/22
- [x] \`pytest tests/news_extraction\` — 9/9
- [ ] Smoke-test the content pipeline with a heavy-URL batch once the stack merges; verify wall-clock time drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)