### PR TITLE
day closing 2026-04-21: changelog + PR review fixes

### DIFF
--- a/changelog/changelog_2026-04-21.md
+++ b/changelog/changelog_2026-04-21.md
@@ -1,7 +1,7 @@
 # Changelog — 2026-04-21
 
 ## Summary
-Completed a code-excellence and performance review of the `news_extraction` module, landing correctness fixes across 14 files, 4 new files, and a new regression test suite. The changes eliminate a class of silent data-loss bugs (watermark skipping, warm-start URL deduplication leakage), fix several concurrency and thread-safety issues, and bring the module's Cloud Function handler from a 501 stub to production-ready.
+Full-day code-excellence review arc: completed a deep correctness + performance pass on `news_extraction` (PRs #119, #120) and then carried the same discipline into a 5-phase refactor of `url_content_extraction` (PRs #121–#123). The combined effort eliminated silent data-loss bugs, fixed concurrency issues, unified a fragmented DB layer, added Playwright browser reuse, and deleted ~900 lines of dead/duplicate code — all with 34/34 tests green at day's end.
 
 ## Changes
 
@@ -93,6 +93,8 @@ Completed a code-excellence and performance review of the `news_extraction` modu
 
 ## Files Modified
 
+### Session 1 — `news_extraction` (PRs #119, #120)
+
 | File | Change |
 |------|--------|
 | `CLAUDE.md` | Added module inventory, clarified pipeline stages 5/6, documented batch_jobs table |
@@ -115,9 +117,58 @@ Completed a code-excellence and performance review of the `news_extraction` modu
 | **NEW** `src/functions/news_extraction/functions/run_local.sh` | Shell wrapper to start local server |
 | **NEW** `tests/news_extraction/test_regressions.py` | 5 regression tests |
 
+### Session 2 — `url_content_extraction` (PRs #121–#123)
+
+| File | Change |
+|------|--------|
+| **NEW** `src/functions/url_content_extraction/core/db/__init__.py` | Package exports for reader + writer |
+| **NEW** `src/functions/url_content_extraction/core/db/reader.py` | `FactsReader` with paginated Supabase reads |
+| **NEW** `src/functions/url_content_extraction/core/db/writer.py` | `FactsWriter`: bulk insert, pooled embed, bucketed mark-complete, force-delete |
+| `src/functions/url_content_extraction/core/facts/__init__.py` | Trimmed to prompt/parser/filter surface; storage API removed; docstring updated |
+| **DELETED** `src/functions/url_content_extraction/core/facts/storage.py` | 345 lines removed; all callers migrated to `core/db` |
+| `src/functions/url_content_extraction/core/pipelines/content_batch_processor.py` | Integrated `extract_many` pre-fetch loop; shared `is_heavy_url` reference |
+| `src/functions/url_content_extraction/core/pipelines/realtime_post_processor.py` | Migrated from inline storage calls to `FactsWriter` |
+| `src/functions/url_content_extraction/core/extractors/playwright_extractor.py` | Added `extract_many` for browser reuse; single-URL path routes through `_extract_one` |
+| `src/functions/url_content_extraction/core/extractors/light_extractor.py` | Shared module-level `httpx.Client`; `is_heavy_url` extracted to module scope |
+| `src/functions/url_content_extraction/scripts/extract_facts_cli.py` | Migrated to `FactsReader`/`FactsWriter`; request-scoped `OpenAI` client; eliminated redundant DB round-trips |
+| **NEW** `tests/url_content_extraction/test_regressions.py` | 25 regression tests covering DB layer, extractors, CLI, and deletion invariants |
+
+---
+
+## Session 2 — `url_content_extraction` refactor arc (PRs #121–#123)
+
+### Phase 3 — Unified DB layer (PR #121)
+
+- **NEW `core/db/reader.py`** — `FactsReader`: paginated reads for `news_facts`, `facts_embeddings`, `story_embeddings`; every multi-row path uses `.range()` pagination per project convention
+- **NEW `core/db/writer.py`** — `FactsWriter`: bulk inserts, pooled embedding upsert, bucketed `mark_completed` (small/medium/large article buckets), force-delete for re-extraction
+- **NEW `core/db/`** replaces three parallel fact-storage implementations that had independently drifted: realtime post-processor, batch result processor, and the older `core/facts/storage` module; all now route through one layer
+- `insert_facts` returns `(ids_by_article, texts_by_id)` so downstream embedding creation skips a redundant `SELECT`
+- `mark_facts_extracted` buckets updates by article size (avoids single-row updates for large articles)
+- Writer supports optional `client` injection for request-scoped credentials (mirrors `image_selection` pattern)
+- Net: +966 / -620 across 6 files; 28/28 tests passing at merge
+
+### Phase 4 — Playwright browser reuse + shared httpx client (PR #122)
+
+- **`PlaywrightExtractor.extract_many(urls)`** — new batch-extraction method that launches Chromium once, walks the URL list on a shared browser + context, and closes one page per URL; single-URL `extract()` preserved and routed through the same `_extract_one` helper
+- **`content_batch_processor`** pre-extracts the entire heavy-URL batch via `extract_many` before the processing loop; net effect: one Chromium launch per run instead of one per heavy URL (~2–3 s saved per heavy URL)
+- Per-URL errors in a batch surface as `ExtractedContent(error=...)` and fall through to standard failure tracking; a complete batch failure is caught and re-raised
+- **`LightExtractor`** now uses a module-level shared `httpx.Client` (persistent connection pool) instead of constructing one per URL; `is_heavy_url()` extracted to module scope so both extractors and the batch processor share the same decision function
+- `content_batch_processor` passes `is_heavy_url` as a parameter rather than re-declaring it
+- Net: +511 / -256 across 4 files; 31/31 tests passing at merge
+
+### Phase 5 — CLI migration + storage.py deletion (PR #123)
+
+- **`scripts/extract_facts_cli.py`** migrated to `FactsReader`/`FactsWriter`; the 50-line force-delete block collapses to `writer.delete_fact_data`; `create_fact_embeddings_sync` now accepts a pre-built `texts_by_id` from the insert step, eliminating a redundant DB round-trip; `create_pooled_embedding` accepts `known_vectors` for the same reason
+- `extract_facts_from_content` uses a request-scoped `OpenAI(api_key=...)` client instead of mutating the module-global `openai.api_key` (fixes a thread-safety hazard in warm Cloud Function instances)
+- **`core/facts/storage.py` deleted** (345 lines); `core/facts/__init__.py` trimmed to the prompt/parser/filter surface; docstring directs new callers to `core/db`
+- 3 new regression tests: `core/facts` no longer exports storage API; `storage.py` module is fully deleted; CLI imports `FactsWriter` not the old storage functions
+- Net: +174 / -529 across 4 files (net −355 lines); 34/34 tests passing at merge
+
+---
+
 ## Code Quality Notes
 
-- Tests: **7 passed, 0 failed** (`tests/news_extraction -v`)
+- Tests: **34 passed, 0 failed** (`tests/url_content_extraction tests/news_extraction -v`); confirmed clean at EOD
 - Full repo tests: pre-existing `tests/knowledge_extraction` failures present (verified not caused by today's changes — confirmed by running against the stashed working tree before changes)
 - No linting step configured for Python modules (no flake8/ruff config found at project root)
 - No new TODO/FIXME/HACK comments introduced; the one pre-existing TODO in `core/contracts/__init__.py` dates to the initial commit
@@ -126,8 +177,10 @@ Completed a code-excellence and performance review of the `news_extraction` modu
 
 ## Open Items / Carry-over
 
-- `core/contracts/__init__.py` has a pre-existing TODO: "Add NewsExtractionRequest, NewsItem, ExtractionResult contracts" — not addressed in this session
-- `AGENTS.md` Testing Guidelines section still says "No automated test suite exists yet" — now stale; updated in today's docs pass
-- `tests/knowledge_extraction` failures are pre-existing and unrelated to this module; investigate in a future session
-- `README.md` for `news_extraction` has a TODO section at the bottom (pre-existing) that could be cleaned up
-- The `max_parallel_fetches` deprecation warning will surface on first run with the old config key; operators should migrate `feeds.yaml` to `max_workers`
+- **PR merge order**: PRs #119–#123 are a stacked series; merge in order (#119 first, #123 last) or retarget each to `main` after the predecessor merges. No conflicts expected.
+- **PR #115** (`fix/pipeline-knowledge-backlog`) has been open since 2026-03-05 — pre-dates today's arc; needs separate review.
+- **`news_extraction/core/contracts/__init__.py`**: pre-existing TODO "Add NewsExtractionRequest, NewsItem, ExtractionResult contracts" — not addressed in this session.
+- **`tests/knowledge_extraction`** failures are pre-existing and unrelated to today's changes; investigate in a future session.
+- **`news_extraction/README.md`** has a TODO section at the bottom (pre-existing); could be cleaned up.
+- **`feeds.yaml` `max_parallel_fetches`** key: operators should migrate to `max_workers` — a deprecation warning is emitted at runtime until it is updated.
+- **`url_content_extraction` README**: may need an update to document the new `core/db/` layer and `extract_many` API; not addressed today.

--- a/src/functions/url_content_extraction/core/db/reader.py
+++ b/src/functions/url_content_extraction/core/db/reader.py
@@ -19,6 +19,33 @@ _DEFAULT_PAGE_SIZE = 1000
 _DEFAULT_CHUNK_SIZE = 100
 
 
+def _parse_vector_string(value: str) -> Optional[List[float]]:
+    """Parse a pgvector/Supabase embedding string into a list of floats.
+
+    Supports both JSON-array form (``"[0.1, 0.2]"``) and the raw pgvector
+    text form. Returns ``None`` on parse failure so callers can skip the row.
+    """
+    import json
+
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        parsed = json.loads(stripped)
+        if isinstance(parsed, list):
+            return [float(v) for v in parsed]
+    except Exception:
+        pass
+    if stripped.startswith("[") and stripped.endswith("]"):
+        stripped = stripped[1:-1].strip()
+    if not stripped:
+        return None
+    try:
+        return [float(part.strip()) for part in stripped.split(",") if part.strip()]
+    except ValueError:
+        return None
+
+
 class FactsReader:
     """Read-only accessor around the facts schema for a given Supabase client."""
 
@@ -124,20 +151,27 @@ class FactsReader:
         article_ids: Sequence[str],
         *,
         chunk_size: int = _DEFAULT_CHUNK_SIZE,
+        page_size: int = _DEFAULT_PAGE_SIZE,
     ) -> List[str]:
         """Flat list of fact IDs across the supplied articles (any prompt version)."""
         out: List[str] = []
         ids = list(article_ids)
         for i in range(0, len(ids), chunk_size):
             chunk = ids[i : i + chunk_size]
-            response = (
-                self.client.table("news_facts")
-                .select("id")
-                .in_("news_url_id", chunk)
-                .execute()
-            )
-            rows = getattr(response, "data", []) or []
-            out.extend(row.get("id") for row in rows if row.get("id"))
+            offset = 0
+            while True:
+                response = (
+                    self.client.table("news_facts")
+                    .select("id")
+                    .in_("news_url_id", chunk)
+                    .range(offset, offset + page_size - 1)
+                    .execute()
+                )
+                rows = getattr(response, "data", []) or []
+                out.extend(row.get("id") for row in rows if row.get("id"))
+                if len(rows) < page_size:
+                    break
+                offset += page_size
         return out
 
     # ------------------------------------------------------------------
@@ -176,8 +210,6 @@ class FactsReader:
         chunk_size: int = _DEFAULT_PAGE_SIZE,
     ) -> List[List[float]]:
         """Return embedding vectors for the supplied fact IDs (parse-safe)."""
-        import json
-
         vectors: List[List[float]] = []
         ids = list(fact_ids)
         for i in range(0, len(ids), chunk_size):
@@ -192,9 +224,8 @@ class FactsReader:
             for row in rows:
                 vector = row.get("embedding_vector")
                 if isinstance(vector, str):
-                    try:
-                        vector = json.loads(vector.strip("[]"))
-                    except Exception:
+                    vector = _parse_vector_string(vector)
+                    if vector is None:
                         continue
                 if isinstance(vector, list) and vector:
                     vectors.append(vector)

--- a/src/functions/url_content_extraction/core/db/writer.py
+++ b/src/functions/url_content_extraction/core/db/writer.py
@@ -295,18 +295,25 @@ class FactsWriter:
         if not ids:
             return 0
 
-        # 1. collect all fact IDs
+        # 1. collect all fact IDs (paginated to respect the 1000-row cap)
+        page_size = 1000
         all_fact_ids: List[str] = []
         for i in range(0, len(ids), chunk_size):
             chunk = ids[i : i + chunk_size]
-            response = (
-                self.client.table("news_facts")
-                .select("id")
-                .in_("news_url_id", chunk)
-                .execute()
-            )
-            rows = getattr(response, "data", []) or []
-            all_fact_ids.extend(row.get("id") for row in rows if row.get("id"))
+            offset = 0
+            while True:
+                response = (
+                    self.client.table("news_facts")
+                    .select("id")
+                    .in_("news_url_id", chunk)
+                    .range(offset, offset + page_size - 1)
+                    .execute()
+                )
+                rows = getattr(response, "data", []) or []
+                all_fact_ids.extend(row.get("id") for row in rows if row.get("id"))
+                if len(rows) < page_size:
+                    break
+                offset += page_size
 
         # 2. delete fact-scoped rows
         for i in range(0, len(all_fact_ids), chunk_size):

--- a/src/functions/url_content_extraction/core/extractors/playwright_extractor.py
+++ b/src/functions/url_content_extraction/core/extractors/playwright_extractor.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Any, Iterable, List, Optional, Sequence
+from typing import Any, List, Optional, Sequence, Tuple
 
 from bs4 import BeautifulSoup
 
@@ -149,7 +149,9 @@ class PlaywrightExtractor:
         if not url_list:
             return []
 
-        option_sets: List[ExtractionOptions] = []
+        # Validate per URL so one malformed entry doesn't abort the whole batch
+        # and force a fallback to per-URL extraction (losing browser-reuse).
+        entries: List[Tuple[str, Optional[ExtractionOptions], Optional[str]]] = []
         for url in url_list:
             merged_options: dict[str, object] = {"url": url}
             if timeout:
@@ -158,21 +160,32 @@ class PlaywrightExtractor:
                 merged_options.update(
                     options if isinstance(options, dict) else options.model_dump()
                 )
-            option_sets.append(parse_options(merged_options))
+            try:
+                entries.append((url, parse_options(merged_options), None))
+            except Exception as exc:
+                entries.append((url, None, f"Invalid extraction options: {exc}"))
 
-        total_timeout = sum(opt.timeout_seconds for opt in option_sets) + 30
-        return self._run_async(self._extract_batch(option_sets), total_timeout)
+        valid_options = [opt for _, opt, err in entries if opt is not None and err is None]
+        if not valid_options:
+            return [
+                ExtractedContent(url=url, error=err or "Invalid URL")
+                for url, _, err in entries
+            ]
+
+        total_timeout = sum(opt.timeout_seconds for opt in valid_options) + 30
+        return self._run_async(self._extract_batch(entries), total_timeout)
 
     async def _extract_batch(
-        self, option_sets: List[ExtractionOptions]
+        self,
+        entries: List[Tuple[str, Optional[ExtractionOptions], Optional[str]]],
     ) -> List[ExtractedContent]:
         if async_playwright is None:  # pragma: no cover - optional dep missing
             return [
                 ExtractedContent(
-                    url=str(opt.url),
-                    error="Playwright is not available in the current environment",
+                    url=url,
+                    error=err or "Playwright is not available in the current environment",
                 )
-                for opt in option_sets
+                for url, _, err in entries
             ]
 
         results: List[ExtractedContent] = []
@@ -181,7 +194,12 @@ class PlaywrightExtractor:
             try:
                 context = await self._new_context(browser)
                 try:
-                    for opts in option_sets:
+                    for url, opts, err in entries:
+                        if opts is None or err is not None:
+                            results.append(
+                                ExtractedContent(url=url, error=err or "Invalid URL")
+                            )
+                            continue
                         context.set_default_navigation_timeout(
                             opts.timeout_seconds * 1000
                         )


### PR DESCRIPTION
## Summary

- Appends the url_content_extraction 5-phase refactor arc to \`changelog/changelog_2026-04-21.md\`.
- Addresses review comments surfaced on PRs #119-#123 after they were opened:
  - \`db/reader.py\` — fix pgvector/Supabase embedding string parsing (\`strip('[]')\` + \`json.loads\` produced invalid JSON for \`"[0.1,0.2]"\`); share parsing via \`_parse_vector_string\`.
  - \`db/reader.py\` — paginate \`fetch_fact_ids_for_articles\` via \`.range()\` so articles with >1000 facts don't silently truncate.
  - \`db/writer.py\` — paginate fact-id collection in \`delete_fact_data\` so force re-extraction doesn't leave orphan downstream rows.
  - \`extractors/playwright_extractor.py\` — drop unused \`Iterable\` import; validate options per URL in \`extract_many\` so one malformed entry surfaces as \`ExtractedContent(error=...)\` instead of aborting the whole heavy-URL batch and losing browser-reuse.

## Test plan

- [x] \`pytest tests/url_content_extraction tests/news_extraction\` — 34/34
- [x] Local \`run_local.sh\` smoke test against an ESPN article (browser-reuse path verified).