### PR TITLE
fix: backport codex review fixes to url_content + article_knowledge services

### DIFF
--- a/src/functions/article_knowledge_extraction/functions/local_server.py
+++ b/src/functions/article_knowledge_extraction/functions/local_server.py
@@ -12,7 +12,13 @@ project_root = Path(__file__).resolve().parents[4]
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-from src.functions.article_knowledge_extraction.functions.main import (
+# IMPORTANT: ``main.py`` snapshots ``WORKER_URL`` at import time. Set it
+# BEFORE importing the handlers so submit can fire-and-forget locally
+# without relying on the cleanup cron to requeue.
+_PORT = int(os.environ.get("PORT", 8080))
+os.environ.setdefault("WORKER_URL", f"http://localhost:{_PORT}/worker")
+
+from src.functions.article_knowledge_extraction.functions.main import (  # noqa: E402
     health_check_handler,
     poll_handler,
     submit_handler,
@@ -43,10 +49,6 @@ def _health():
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get("PORT", 8080))
-    # By default, WORKER_URL in this local server points back at /worker on
-    # the same port so submit can fire-and-forget locally without cron.
-    os.environ.setdefault("WORKER_URL", f"http://localhost:{port}/worker")
-    print(f"Starting article_knowledge_extraction local server on http://localhost:{port}")
+    print(f"Starting article_knowledge_extraction local server on http://localhost:{_PORT}")
     print("Endpoints: POST /submit, POST /poll, POST /worker, GET /health")
-    app.run(host="0.0.0.0", port=port, debug=True)
+    app.run(host="0.0.0.0", port=_PORT, debug=True)

--- a/src/functions/article_knowledge_extraction/scripts/cleanup_expired_jobs_cli.py
+++ b/src/functions/article_knowledge_extraction/scripts/cleanup_expired_jobs_cli.py
@@ -159,7 +159,12 @@ def main() -> int:
             },
         }
         try:
-            requests.post(worker_url, json=payload, headers=headers, timeout=(3, 3))
+            response = requests.post(
+                worker_url, json=payload, headers=headers, timeout=(3, 3)
+            )
+            # 403/500 without raise_for_status would silently count as
+            # "requeued" — misleading ops signal + stale jobs never recover.
+            response.raise_for_status()
             sent += 1
         except requests.RequestException as exc:
             logger.warning("Failed to requeue job %s: %s", job_id, exc)

--- a/src/functions/url_content_extraction_service/functions/local_server.py
+++ b/src/functions/url_content_extraction_service/functions/local_server.py
@@ -12,7 +12,13 @@ project_root = Path(__file__).resolve().parents[4]
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-from src.functions.url_content_extraction_service.functions.main import (
+# IMPORTANT: ``main.py`` snapshots ``WORKER_URL`` at import time. Set it
+# BEFORE importing the handlers, otherwise local /submit logs
+# "WORKER_URL not configured" and the worker self-invoke never fires.
+_PORT = int(os.environ.get("PORT", 8080))
+os.environ.setdefault("WORKER_URL", f"http://localhost:{_PORT}/worker")
+
+from src.functions.url_content_extraction_service.functions.main import (  # noqa: E402
     health_check_handler,
     poll_handler,
     submit_handler,
@@ -43,8 +49,6 @@ def _health():
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get("PORT", 8080))
-    os.environ.setdefault("WORKER_URL", f"http://localhost:{port}/worker")
-    print(f"Starting url_content_extraction_service local server on http://localhost:{port}")
+    print(f"Starting url_content_extraction_service local server on http://localhost:{_PORT}")
     print("Endpoints: POST /submit, POST /poll, POST /worker, GET /health")
-    app.run(host="0.0.0.0", port=port, debug=True)
+    app.run(host="0.0.0.0", port=_PORT, debug=True)

--- a/src/functions/url_content_extraction_service/scripts/cleanup_expired_jobs_cli.py
+++ b/src/functions/url_content_extraction_service/scripts/cleanup_expired_jobs_cli.py
@@ -134,7 +134,12 @@ def main() -> int:
             },
         }
         try:
-            requests.post(worker_url, json=payload, headers=headers, timeout=(3, 3))
+            response = requests.post(
+                worker_url, json=payload, headers=headers, timeout=(3, 3)
+            )
+            # 403/500 without raise_for_status would silently count as
+            # "requeued" — misleading ops signal + stale jobs never recover.
+            response.raise_for_status()
             sent += 1
         except requests.RequestException as exc:
             logger.warning("Failed to requeue job %s: %s", job_id, exc)

--- a/src/functions/url_content_extraction_service/scripts/poll_job_cli.py
+++ b/src/functions/url_content_extraction_service/scripts/poll_job_cli.py
@@ -22,6 +22,11 @@ from src.shared.utils.env import load_env
 
 
 def main() -> int:
+    # Load the central .env BEFORE argparse reads os.getenv for defaults —
+    # otherwise SUPABASE_URL / SUPABASE_KEY from the repo-root .env are
+    # never picked up and callers must always pass --supabase-* flags.
+    load_env()
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--url", required=True, help="Poll endpoint URL")
     parser.add_argument("--job-id", required=True)
@@ -32,7 +37,6 @@ def main() -> int:
     parser.add_argument("--max-seconds", type=float, default=300.0)
     args = parser.parse_args()
 
-    load_env()
     if not args.supabase_url or not args.supabase_key:
         print("supabase url + key are required", file=sys.stderr)
         return 2

--- a/src/functions/url_content_extraction_service/scripts/submit_job_cli.py
+++ b/src/functions/url_content_extraction_service/scripts/submit_job_cli.py
@@ -23,6 +23,11 @@ from src.shared.utils.env import load_env
 
 
 def main() -> int:
+    # Load the central .env BEFORE argparse reads os.getenv for defaults —
+    # otherwise SUPABASE_URL / SUPABASE_KEY from the repo-root .env are
+    # never picked up and callers must always pass --supabase-* flags.
+    load_env()
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--url", required=True, help="Submit endpoint URL")
     parser.add_argument(
@@ -37,7 +42,6 @@ def main() -> int:
     parser.add_argument("--force-playwright", action="store_true")
     args = parser.parse_args()
 
-    load_env()
     if not args.supabase_url or not args.supabase_key:
         print("supabase url + key are required", file=sys.stderr)
         return 2


### PR DESCRIPTION
## Summary

Same four bugs identified by Codex on PR #127 also exist in the two earlier
services (url_content_extraction_service and article_knowledge_extraction) —
PR #127 inherited them by templating. Backporting the fixes here so all
three services stay consistent.

## What's changed

### url_content_extraction_service (4 fixes)

1. **`functions/local_server.py`** — Move \`WORKER_URL\` env mutation BEFORE
   the handlers import. \`main.py\` snapshots \`WORKER_URL\` at module-load
   time, so setting it in the \`__main__\` block (after import) meant
   local \`/submit\` could never self-invoke the worker.
2. **\`scripts/cleanup_expired_jobs_cli.py\`** — Add
   \`response.raise_for_status()\` so 403/500 responses don't get silently
   counted as successful requeues.
3. **\`scripts/submit_job_cli.py\`** — Move \`load_env()\` BEFORE the argparse
   parser is constructed. Defaults (\`os.getenv(\"SUPABASE_URL\")\`) are
   evaluated at parser-construction time, so loading \`.env\` after
   \`parse_args()\` made central env values unreachable.
4. **\`scripts/poll_job_cli.py\`** — Same \`load_env()\` ordering fix.

### article_knowledge_extraction (2 fixes)

1. **\`functions/local_server.py\`** — Same WORKER_URL import-order fix.
2. **\`scripts/cleanup_expired_jobs_cli.py\`** — Same raise_for_status fix.

Article's \`submit\` and \`poll\` CLIs use a different pattern
(\`args.x or os.getenv(X)\` resolved AFTER \`load_env()\`), so they don't
carry the .env-ordering bug.

## Test plan

- [x] \`pytest tests/url_content_extraction_service/ tests/article_knowledge_extraction/ tests/url_content_extraction/\` — 63/63 passing
- [x] Manual import-order check: in both modified local servers, \`WORKER_URL\` env value now reaches \`main.WORKER_URL\` snapshot at import time

## References

- Original Codex review on PR #127: 4 P2 findings, all valid
- PR #127 fix commit: \`b0d0917\` (applied to news_extraction_service)
- This PR is the backport for the two pre-existing services

🤖 Generated with [Claude Code](https://claude.com/claude-code)