### PR TITLE
Read service secrets from runtime env, require caller bearer token (#12)

### DIFF
--- a/src/functions/article_knowledge_extraction/core/factory.py
+++ b/src/functions/article_knowledge_extraction/core/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, Optional
 
 from .config import (
@@ -16,6 +17,11 @@ from .config import (
 
 
 def _parse_llm(payload: Optional[Dict[str, Any]]) -> Optional[LLMConfig]:
+    """Hydrate LLMConfig from payload (non-secret fields) + env-provided api_key.
+
+    Callers never send the OpenAI API key in the request body; the function
+    reads it from its own runtime env (``OPENAI_API_KEY``).
+    """
     if payload is None:
         return None
     if not isinstance(payload, dict):
@@ -23,7 +29,7 @@ def _parse_llm(payload: Optional[Dict[str, Any]]) -> Optional[LLMConfig]:
     return LLMConfig(
         provider=payload.get("provider", "openai"),
         model=payload.get("model", "gpt-5.4-mini"),
-        api_key=payload.get("api_key", ""),
+        api_key=os.getenv("OPENAI_API_KEY", ""),
         parameters=payload.get("parameters") or {},
         timeout_seconds=int(payload.get("timeout_seconds", 60)),
         max_retries=int(payload.get("max_retries", 2)),
@@ -31,13 +37,18 @@ def _parse_llm(payload: Optional[Dict[str, Any]]) -> Optional[LLMConfig]:
 
 
 def _parse_supabase(payload: Optional[Dict[str, Any]]) -> Optional[SupabaseConfig]:
+    """Hydrate SupabaseConfig from payload url/jobs_table + env-provided key.
+
+    Callers never send the service-role key in the request body; the function
+    reads it from its own runtime env (``SUPABASE_SERVICE_ROLE_KEY``).
+    """
     if payload is None:
         return None
     if not isinstance(payload, dict):
         raise ValueError("supabase must be an object when provided")
     return SupabaseConfig(
         url=payload.get("url", ""),
-        key=payload.get("key", ""),
+        key=os.getenv("SUPABASE_SERVICE_ROLE_KEY", ""),
         jobs_table=payload.get("jobs_table", "article_knowledge_extraction_jobs"),
     )
 

--- a/src/functions/article_knowledge_extraction/core/worker/job_runner.py
+++ b/src/functions/article_knowledge_extraction/core/worker/job_runner.py
@@ -7,6 +7,7 @@ writes a terminal state. Idempotent: if the job is already terminal, no-op.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any, Dict
 
 from ..config import (
@@ -103,15 +104,22 @@ def _rehydrate(payload: Dict[str, Any]):
     )
     options.validate()
 
+    # Read the OpenAI key from the worker's own runtime env — never from the
+    # stored job row, so the secret doesn't live in the database.
+    api_key = os.getenv("OPENAI_API_KEY", "")
     llm = LLMConfig(
         provider=llm_payload.get("provider", "openai"),
         model=llm_payload.get("model", "gpt-5.4-mini"),
-        api_key=llm_payload.get("api_key", ""),
+        api_key=api_key,
         parameters=llm_payload.get("parameters") or {},
         timeout_seconds=int(llm_payload.get("timeout_seconds", 60)),
         max_retries=int(llm_payload.get("max_retries", 2)),
     )
-    if not llm.api_key or not llm.model:
-        raise ValueError("llm.api_key and llm.model are required in the stored job input")
+    if not llm.api_key:
+        raise ValueError(
+            "OPENAI_API_KEY must be set in the worker's runtime env"
+        )
+    if not llm.model:
+        raise ValueError("llm.model is required in the stored job input")
 
     return article, options, llm

--- a/src/functions/article_knowledge_extraction/functions/deploy.sh
+++ b/src/functions/article_knowledge_extraction/functions/deploy.sh
@@ -54,6 +54,21 @@ if [ -z "$WORKER_TOKEN" ]; then
   echo "     WORKER_TOKEN=$WORKER_TOKEN"
 fi
 
+# Require runtime secrets that the functions now read from env instead of the
+# request body (see issue #12 — service secrets no longer travel in payloads).
+if [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+  error "SUPABASE_SERVICE_ROLE_KEY not set. Export it before running this script."
+  exit 1
+fi
+if [ -z "$OPENAI_API_KEY" ]; then
+  error "OPENAI_API_KEY not set. Export it before running this script."
+  exit 1
+fi
+if [ -z "$EXTRACTION_FUNCTION_AUTH_TOKEN" ]; then
+  error "EXTRACTION_FUNCTION_AUTH_TOKEN not set. Export it before running this script."
+  exit 1
+fi
+
 # Move to project root (functions -> article_knowledge_extraction -> functions -> src -> root)
 cd ../../../..
 
@@ -137,7 +152,7 @@ fn_url() {
 
 # 1. Worker first, so we can read its URL.
 deploy_fn "$WORKER_FN" "$WORKER_ENTRY" \
-  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_TOKEN=${WORKER_TOKEN}" \
+  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_TOKEN=${WORKER_TOKEN},SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY},OPENAI_API_KEY=${OPENAI_API_KEY}" \
   --clear-secrets
 
 WORKER_URL=$(fn_url "$WORKER_FN")
@@ -149,12 +164,12 @@ info "Worker URL: $WORKER_URL"
 
 # 2. Poll (no worker dependency).
 deploy_fn "$POLL_FN" "$POLL_ENTRY" \
-  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV}" \
+  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY},EXTRACTION_FUNCTION_AUTH_TOKEN=${EXTRACTION_FUNCTION_AUTH_TOKEN}" \
   --clear-secrets
 
 # 3. Submit, with WORKER_URL + WORKER_TOKEN wired in.
 deploy_fn "$SUBMIT_FN" "$SUBMIT_ENTRY" \
-  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_URL=${WORKER_URL},WORKER_TOKEN=${WORKER_TOKEN}" \
+  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_URL=${WORKER_URL},WORKER_TOKEN=${WORKER_TOKEN},SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY},OPENAI_API_KEY=${OPENAI_API_KEY},EXTRACTION_FUNCTION_AUTH_TOKEN=${EXTRACTION_FUNCTION_AUTH_TOKEN}" \
   --clear-secrets
 
 echo ""

--- a/src/functions/article_knowledge_extraction/functions/main.py
+++ b/src/functions/article_knowledge_extraction/functions/main.py
@@ -48,6 +48,29 @@ logger = logging.getLogger(__name__)
 
 WORKER_URL = os.getenv("WORKER_URL", "")
 WORKER_TOKEN = os.getenv("WORKER_TOKEN", "")
+# Shared bearer token that authenticates submit/poll callers. Fails closed:
+# if the env var is unset we reject every call rather than silently accepting
+# anonymous traffic, since anonymous traffic would run on our Supabase+LLM
+# credentials.
+CALLER_TOKEN = os.getenv("EXTRACTION_FUNCTION_AUTH_TOKEN", "")
+
+
+def _check_caller_auth(request: flask.Request) -> flask.Response | None:
+    if not CALLER_TOKEN:
+        logger.error(
+            "EXTRACTION_FUNCTION_AUTH_TOKEN is not configured; rejecting caller"
+        )
+        return _error_response(
+            "Service misconfigured: caller auth token not set", status=503
+        )
+    header = request.headers.get("Authorization", "")
+    prefix = "Bearer "
+    if not header.startswith(prefix) or not hmac.compare_digest(
+        header[len(prefix):], CALLER_TOKEN
+    ):
+        logger.warning("submit/poll handler rejected unauthenticated request")
+        return _error_response("Unauthorized", status=401)
+    return None
 
 
 # --------------------------------------------------------------------- handlers
@@ -58,6 +81,10 @@ def submit_handler(request: flask.Request) -> flask.Response:
         return _cors_response({}, status=204)
     if request.method != "POST":
         return _error_response("Method not allowed. Use POST.", status=405)
+
+    auth_error = _check_caller_auth(request)
+    if auth_error is not None:
+        return auth_error
 
     try:
         payload = request.get_json(silent=True) or {}
@@ -82,7 +109,8 @@ def submit_handler(request: flask.Request) -> flask.Response:
         "llm": {
             "provider": req.llm.provider,
             "model": req.llm.model,
-            "api_key": req.llm.api_key,
+            # api_key intentionally omitted: the worker reads OPENAI_API_KEY
+            # from its own runtime env so the secret never lives in the DB row.
             "parameters": req.llm.parameters,
             "timeout_seconds": req.llm.timeout_seconds,
             "max_retries": req.llm.max_retries,
@@ -113,6 +141,10 @@ def poll_handler(request: flask.Request) -> flask.Response:
         return _cors_response({}, status=204)
     if request.method != "POST":
         return _error_response("Method not allowed. Use POST.", status=405)
+
+    auth_error = _check_caller_auth(request)
+    if auth_error is not None:
+        return auth_error
 
     try:
         payload = request.get_json(silent=True) or {}
@@ -186,7 +218,8 @@ def _fire_worker(job_id: str, supabase_config) -> None:
         "job_id": job_id,
         "supabase": {
             "url": supabase_config.url,
-            "key": supabase_config.key,
+            # key intentionally omitted: the worker reads
+            # SUPABASE_SERVICE_ROLE_KEY from its own runtime env.
             "jobs_table": supabase_config.jobs_table,
         },
     }
@@ -205,7 +238,9 @@ def _cors_response(body, status: int = 200) -> flask.Response:
     response.headers["Content-Type"] = "application/json"
     response.headers["Access-Control-Allow-Origin"] = "*"
     response.headers["Access-Control-Allow-Methods"] = "POST,OPTIONS"
-    response.headers["Access-Control-Allow-Headers"] = "Content-Type,X-Worker-Token"
+    response.headers["Access-Control-Allow-Headers"] = (
+        "Content-Type,X-Worker-Token,Authorization"
+    )
     return response
 
 

--- a/src/functions/news_extraction_service/core/factory.py
+++ b/src/functions/news_extraction_service/core/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
@@ -11,13 +12,18 @@ from .config import ExtractionOptions, PollRequest, SubmitRequest, WorkerRequest
 
 
 def _parse_supabase(payload: Optional[Dict[str, Any]]) -> Optional[SupabaseConfig]:
+    """Hydrate SupabaseConfig from payload url/jobs_table + env-provided key.
+
+    Callers never send the service-role key in the request body; the function
+    reads it from its own runtime env (``SUPABASE_SERVICE_ROLE_KEY``).
+    """
     if payload is None:
         return None
     if not isinstance(payload, dict):
         raise ValueError("supabase must be an object when provided")
     return SupabaseConfig(
         url=payload.get("url", ""),
-        key=payload.get("key", ""),
+        key=os.getenv("SUPABASE_SERVICE_ROLE_KEY", ""),
         jobs_table=payload.get("jobs_table", "extraction_jobs"),
     )
 

--- a/src/functions/news_extraction_service/functions/deploy.sh
+++ b/src/functions/news_extraction_service/functions/deploy.sh
@@ -53,6 +53,17 @@ if [ -z "$WORKER_TOKEN" ]; then
   echo "     WORKER_TOKEN=$WORKER_TOKEN"
 fi
 
+# Require runtime secrets that the functions now read from env instead of the
+# request body (see issue #12 — service secrets no longer travel in payloads).
+if [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+  error "SUPABASE_SERVICE_ROLE_KEY not set. Export it before running this script."
+  exit 1
+fi
+if [ -z "$EXTRACTION_FUNCTION_AUTH_TOKEN" ]; then
+  error "EXTRACTION_FUNCTION_AUTH_TOKEN not set. Export it before running this script."
+  exit 1
+fi
+
 # Move to project root.
 cd ../../../..
 
@@ -146,7 +157,7 @@ fn_url() {
 
 # 1. Worker first.
 deploy_fn "$WORKER_FN" "$WORKER_ENTRY" \
-  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_TOKEN=${WORKER_TOKEN}" \
+  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_TOKEN=${WORKER_TOKEN},SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}" \
   --clear-secrets
 
 WORKER_URL=$(fn_url "$WORKER_FN")
@@ -158,12 +169,12 @@ info "Worker URL: $WORKER_URL"
 
 # 2. Poll (no worker dep).
 deploy_fn "$POLL_FN" "$POLL_ENTRY" \
-  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV}" \
+  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY},EXTRACTION_FUNCTION_AUTH_TOKEN=${EXTRACTION_FUNCTION_AUTH_TOKEN}" \
   --clear-secrets
 
 # 3. Submit, with WORKER_URL + WORKER_TOKEN wired in.
 deploy_fn "$SUBMIT_FN" "$SUBMIT_ENTRY" \
-  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_URL=${WORKER_URL},WORKER_TOKEN=${WORKER_TOKEN}" \
+  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_URL=${WORKER_URL},WORKER_TOKEN=${WORKER_TOKEN},SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY},EXTRACTION_FUNCTION_AUTH_TOKEN=${EXTRACTION_FUNCTION_AUTH_TOKEN}" \
   --clear-secrets
 
 echo ""

--- a/src/functions/news_extraction_service/functions/main.py
+++ b/src/functions/news_extraction_service/functions/main.py
@@ -48,6 +48,29 @@ logger = logging.getLogger(__name__)
 
 WORKER_URL = os.getenv("WORKER_URL", "")
 WORKER_TOKEN = os.getenv("WORKER_TOKEN", "")
+# Shared bearer token that authenticates submit/poll callers. Fails closed:
+# if the env var is unset we reject every call rather than silently accepting
+# anonymous traffic, since anonymous traffic would run on our Supabase+LLM
+# credentials.
+CALLER_TOKEN = os.getenv("EXTRACTION_FUNCTION_AUTH_TOKEN", "")
+
+
+def _check_caller_auth(request: flask.Request) -> flask.Response | None:
+    if not CALLER_TOKEN:
+        logger.error(
+            "EXTRACTION_FUNCTION_AUTH_TOKEN is not configured; rejecting caller"
+        )
+        return _error_response(
+            "Service misconfigured: caller auth token not set", status=503
+        )
+    header = request.headers.get("Authorization", "")
+    prefix = "Bearer "
+    if not header.startswith(prefix) or not hmac.compare_digest(
+        header[len(prefix):], CALLER_TOKEN
+    ):
+        logger.warning("submit/poll handler rejected unauthenticated request")
+        return _error_response("Unauthorized", status=401)
+    return None
 
 
 # --------------------------------------------------------------------- handlers
@@ -58,6 +81,10 @@ def submit_handler(request: flask.Request) -> flask.Response:
         return _cors_response({}, status=204)
     if request.method != "POST":
         return _error_response("Method not allowed. Use POST.", status=405)
+
+    auth_error = _check_caller_auth(request)
+    if auth_error is not None:
+        return auth_error
 
     try:
         payload = request.get_json(silent=True) or {}
@@ -100,6 +127,10 @@ def poll_handler(request: flask.Request) -> flask.Response:
         return _cors_response({}, status=204)
     if request.method != "POST":
         return _error_response("Method not allowed. Use POST.", status=405)
+
+    auth_error = _check_caller_auth(request)
+    if auth_error is not None:
+        return auth_error
 
     try:
         payload = request.get_json(silent=True) or {}
@@ -166,7 +197,8 @@ def _fire_worker(job_id: str, supabase_config) -> None:
         "job_id": job_id,
         "supabase": {
             "url": supabase_config.url,
-            "key": supabase_config.key,
+            # key intentionally omitted: the worker reads
+            # SUPABASE_SERVICE_ROLE_KEY from its own runtime env.
             "jobs_table": supabase_config.jobs_table,
         },
     }
@@ -185,7 +217,9 @@ def _cors_response(body, status: int = 200) -> flask.Response:
     response.headers["Content-Type"] = "application/json"
     response.headers["Access-Control-Allow-Origin"] = "*"
     response.headers["Access-Control-Allow-Methods"] = "POST,OPTIONS"
-    response.headers["Access-Control-Allow-Headers"] = "Content-Type,X-Worker-Token"
+    response.headers["Access-Control-Allow-Headers"] = (
+        "Content-Type,X-Worker-Token,Authorization"
+    )
     return response
 
 

--- a/src/functions/url_content_extraction_service/core/factory.py
+++ b/src/functions/url_content_extraction_service/core/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, Optional
 
 from src.shared.jobs.contracts import SupabaseConfig
@@ -15,13 +16,18 @@ from .config import (
 
 
 def _parse_supabase(payload: Optional[Dict[str, Any]]) -> Optional[SupabaseConfig]:
+    """Hydrate SupabaseConfig from payload url/jobs_table + env-provided key.
+
+    Callers never send the service-role key in the request body; the function
+    reads it from its own runtime env (``SUPABASE_SERVICE_ROLE_KEY``).
+    """
     if payload is None:
         return None
     if not isinstance(payload, dict):
         raise ValueError("supabase must be an object when provided")
     return SupabaseConfig(
         url=payload.get("url", ""),
-        key=payload.get("key", ""),
+        key=os.getenv("SUPABASE_SERVICE_ROLE_KEY", ""),
         jobs_table=payload.get("jobs_table", "extraction_jobs"),
     )
 

--- a/src/functions/url_content_extraction_service/functions/deploy.sh
+++ b/src/functions/url_content_extraction_service/functions/deploy.sh
@@ -55,6 +55,17 @@ if [ -z "$WORKER_TOKEN" ]; then
   echo "     WORKER_TOKEN=$WORKER_TOKEN"
 fi
 
+# Require runtime secrets that the functions now read from env instead of the
+# request body (see issue #12 — service secrets no longer travel in payloads).
+if [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+  error "SUPABASE_SERVICE_ROLE_KEY not set. Export it before running this script."
+  exit 1
+fi
+if [ -z "$EXTRACTION_FUNCTION_AUTH_TOKEN" ]; then
+  error "EXTRACTION_FUNCTION_AUTH_TOKEN not set. Export it before running this script."
+  exit 1
+fi
+
 # Move to project root.
 cd ../../../..
 
@@ -184,7 +195,7 @@ fn_url() {
 
 # 1. Worker first.
 deploy_fn "$WORKER_FN" "$WORKER_ENTRY" \
-  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_TOKEN=${WORKER_TOKEN},PLAYWRIGHT_BROWSERS_PATH=${RUNTIME_PLAYWRIGHT_PATH}" \
+  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_TOKEN=${WORKER_TOKEN},PLAYWRIGHT_BROWSERS_PATH=${RUNTIME_PLAYWRIGHT_PATH},SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}" \
   --clear-secrets
 
 WORKER_URL=$(fn_url "$WORKER_FN")
@@ -196,12 +207,12 @@ info "Worker URL: $WORKER_URL"
 
 # 2. Poll (no worker dep, no Playwright needed).
 deploy_fn "$POLL_FN" "$POLL_ENTRY" \
-  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV}" \
+  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY},EXTRACTION_FUNCTION_AUTH_TOKEN=${EXTRACTION_FUNCTION_AUTH_TOKEN}" \
   --clear-secrets
 
 # 3. Submit, with WORKER_URL + WORKER_TOKEN wired in.
 deploy_fn "$SUBMIT_FN" "$SUBMIT_ENTRY" \
-  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_URL=${WORKER_URL},WORKER_TOKEN=${WORKER_TOKEN}" \
+  --set-env-vars="LOG_LEVEL=${LOG_LEVEL_ENV},WORKER_URL=${WORKER_URL},WORKER_TOKEN=${WORKER_TOKEN},SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY},EXTRACTION_FUNCTION_AUTH_TOKEN=${EXTRACTION_FUNCTION_AUTH_TOKEN}" \
   --clear-secrets
 
 echo ""

--- a/src/functions/url_content_extraction_service/functions/main.py
+++ b/src/functions/url_content_extraction_service/functions/main.py
@@ -50,6 +50,29 @@ logger = logging.getLogger(__name__)
 
 WORKER_URL = os.getenv("WORKER_URL", "")
 WORKER_TOKEN = os.getenv("WORKER_TOKEN", "")
+# Shared bearer token that authenticates submit/poll callers. Fails closed:
+# if the env var is unset we reject every call rather than silently accepting
+# anonymous traffic, since anonymous traffic would run on our Supabase+LLM
+# credentials.
+CALLER_TOKEN = os.getenv("EXTRACTION_FUNCTION_AUTH_TOKEN", "")
+
+
+def _check_caller_auth(request: flask.Request) -> flask.Response | None:
+    if not CALLER_TOKEN:
+        logger.error(
+            "EXTRACTION_FUNCTION_AUTH_TOKEN is not configured; rejecting caller"
+        )
+        return _error_response(
+            "Service misconfigured: caller auth token not set", status=503
+        )
+    header = request.headers.get("Authorization", "")
+    prefix = "Bearer "
+    if not header.startswith(prefix) or not hmac.compare_digest(
+        header[len(prefix):], CALLER_TOKEN
+    ):
+        logger.warning("submit/poll handler rejected unauthenticated request")
+        return _error_response("Unauthorized", status=401)
+    return None
 
 
 # --------------------------------------------------------------------- handlers
@@ -60,6 +83,10 @@ def submit_handler(request: flask.Request) -> flask.Response:
         return _cors_response({}, status=204)
     if request.method != "POST":
         return _error_response("Method not allowed. Use POST.", status=405)
+
+    auth_error = _check_caller_auth(request)
+    if auth_error is not None:
+        return auth_error
 
     try:
         payload = request.get_json(silent=True) or {}
@@ -103,6 +130,10 @@ def poll_handler(request: flask.Request) -> flask.Response:
         return _cors_response({}, status=204)
     if request.method != "POST":
         return _error_response("Method not allowed. Use POST.", status=405)
+
+    auth_error = _check_caller_auth(request)
+    if auth_error is not None:
+        return auth_error
 
     try:
         payload = request.get_json(silent=True) or {}
@@ -170,7 +201,8 @@ def _fire_worker(job_id: str, supabase_config) -> None:
         "job_id": job_id,
         "supabase": {
             "url": supabase_config.url,
-            "key": supabase_config.key,
+            # key intentionally omitted: the worker reads
+            # SUPABASE_SERVICE_ROLE_KEY from its own runtime env.
             "jobs_table": supabase_config.jobs_table,
         },
     }
@@ -189,7 +221,9 @@ def _cors_response(body, status: int = 200) -> flask.Response:
     response.headers["Content-Type"] = "application/json"
     response.headers["Access-Control-Allow-Origin"] = "*"
     response.headers["Access-Control-Allow-Methods"] = "POST,OPTIONS"
-    response.headers["Access-Control-Allow-Headers"] = "Content-Type,X-Worker-Token"
+    response.headers["Access-Control-Allow-Headers"] = (
+        "Content-Type,X-Worker-Token,Authorization"
+    )
     return response
 
 


### PR DESCRIPTION
## Summary
- Submit/poll handlers in all three extraction services now require `EXTRACTION_FUNCTION_AUTH_TOKEN` as a shared bearer; they reject anonymous calls with 401 (and fail-closed 503 if the env var is unset).
- `_parse_supabase` hydrates the Supabase service-role key from `SUPABASE_SERVICE_ROLE_KEY` env instead of the request body.
- Knowledge extraction additionally reads `OPENAI_API_KEY` from env in both the submit factory and the worker's job rehydrator; `api_key` is no longer stored on the DB job row.
- Submit → worker fire-and-forget body drops the Supabase key; workers read it from their own env.
- `deploy.sh` scripts enforce the new env vars up front and pass them through to `--set-env-vars` so redeploys don't wipe them.

Paired with [t4l_editorial_cycle PR #16](https://github.com/BigSlikTobi/t4l_editorial_cycle/pull/16) — client-side counterpart. Merge both together.

Closes t4l_editorial_cycle#12.

## Test plan
- [x] Server-side changes deployed live to Cloud Run via `deploy.sh` for all three services.
- [x] End-to-end ingestion-worker run against these deployed services completed green.
- [x] Merge alongside t4l_editorial_cycle PR #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)